### PR TITLE
#126 fixed cuda13 issues and arm/sse problem in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,13 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
 endif(MSVC)
 #-----------------------------------------------------------------------------
+# Silence GCC's informational -Wpsabi note about the std::pair<double,double>
+# parameter-passing ABI change in GCC 10.1, emitted by the vendored RNifti header.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-psabi")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
+endif()
+#-----------------------------------------------------------------------------
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   add_definitions(-fPIC)
 endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -73,7 +80,13 @@ option(BUILD_TESTING "To build the unit tests" OFF)
 option(USE_CUDA "To use the CUDA platform" OFF)
 option(USE_OPENCL "To use the OpenCL platform" OFF)
 option(USE_OPENMP "To use OpenMP for multi-CPU processing" ON)
-option(USE_SSE "To enable SSE computation in some case" ON)
+# SSE is an x86-only instruction set, so default it off on other architectures (e.g. ARM/aarch64)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(^|[^a-zA-Z])([xX]86|[xX]86_64|[aA][mM][dD]64|i[3-6]86)$")
+  set(NR_SSE_DEFAULT ON)
+else()
+  set(NR_SSE_DEFAULT OFF)
+endif()
+option(USE_SSE "To enable SSE computation in some case" ${NR_SSE_DEFAULT})
 option(CHECK_GPU "To check if a GPU is available" ON)
 #-----------------------------------------------------------------------------
 option(USE_NRRD "To use the NRRD file format" OFF)
@@ -169,11 +182,44 @@ if(USE_CUDA)
     message(SEND_ERROR "CUDA not found. The USE_CUDA flag is turned OFF")
   else(NOT CMAKE_CUDA_COMPILER)
     include_directories(SYSTEM ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+    # CUDA 13 relocated the bundled CCCL headers (Thrust, CUB, libcu++) into an
+    # "include/cccl" subdirectory which is not part of the default toolkit include
+    # path, so add it explicitly when present to keep <thrust/...> includes working.
+    foreach(_cuda_inc_dir ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+      if(EXISTS "${_cuda_inc_dir}/cccl/thrust")
+        include_directories(SYSTEM "${_cuda_inc_dir}/cccl")
+      endif()
+    endforeach()
     include_directories(${CMAKE_SOURCE_DIR}/reg-lib/cuda)
     add_definitions(-DUSE_CUDA)
+    # FMA (fused multiply-add) contraction is faster but makes GPU results diverge from the
+    # CPU by 1-2 ULP, which breaks the bit-exact CPU-vs-CUDA regression tests. Default it OFF
+    # when building the tests (so CPU and GPU agree exactly) and ON otherwise (performance).
+    # Both the device (--fmad) and the host (-ffp-contract) must match for bit-exact results.
+    if(BUILD_TESTING)
+      set(NR_CUDA_FMA_DEFAULT OFF)
+    else()
+      set(NR_CUDA_FMA_DEFAULT ON)
+    endif()
+    option(USE_CUDA_FMA "Enable FMA contraction in host and device maths (faster, but CPU and GPU results differ by ULPs)" ${NR_CUDA_FMA_DEFAULT})
+    if(NOT USE_CUDA_FMA)
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --fmad=false")
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffp-contract=off")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off")
+      endif()
+      message(STATUS "CUDA FMA contraction disabled (USE_CUDA_FMA=OFF): CPU and GPU results match bit-exactly")
+    else()
+      message(STATUS "CUDA FMA contraction enabled (USE_CUDA_FMA=ON): preferring performance over CPU/GPU bit-exactness")
+    endif()
   endif(NOT CMAKE_CUDA_COMPILER)
 endif(USE_CUDA)
 #-----------------------------------------------------------------------------
+if(USE_SSE AND NOT NR_SSE_DEFAULT)
+  # SSE is not available on this architecture (e.g. ARM/aarch64) - force it off
+  message(STATUS "SSE is not supported on ${CMAKE_SYSTEM_PROCESSOR}, forcing USE_SSE to OFF")
+  set(USE_SSE OFF CACHE BOOL "To enable SSE computation in some case" FORCE)
+endif()
 if(USE_SSE)
   if(NOT MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3")

--- a/reg-apps/reg_average.cpp
+++ b/reg-apps/reg_average.cpp
@@ -506,7 +506,8 @@ int main(int argc, char **argv)
       while(fscanf(cmd_file," %511s", buffer)==1){
          int length = strchr(buffer, '\0')-buffer+1;
          if(strcmp(buffer, "-omp")==0){
-            fscanf(cmd_file," %511s", buffer);
+            if(fscanf(cmd_file," %511s", buffer)!=1)
+               NR_FATAL_ERROR("The -omp flag in the command file must be followed by the number of threads");
 #ifdef _OPENMP
             omp_set_num_threads(atoi(buffer));
             NR_DEBUG("OpenMP core number set to: " << buffer);

--- a/reg-io/png/CMakeLists.txt
+++ b/reg-io/png/CMakeLists.txt
@@ -46,6 +46,10 @@ if(BUILD_INTERNAL_PNG OR BUILD_ALL_DEP)
     )
     # Build the library
     add_library(png STATIC ${png_srcs})
+    # This bundled libpng copy does not ship the arm/ NEON intrinsics sources, so
+    # on ARM (e.g. aarch64) the default PNG_ARM_NEON_OPT=2 would reference NEON
+    # symbols that are never compiled, breaking the link. Disable the optimisation.
+    target_compile_definitions(png PRIVATE PNG_ARM_NEON_OPT=0)
     target_link_libraries(png z)
     install(TARGETS png
         LIBRARY DESTINATION lib COMPONENT Development

--- a/reg-lib/cuda/CudaCommon.hpp
+++ b/reg-lib/cuda/CudaCommon.hpp
@@ -66,6 +66,24 @@ inline void CheckKernel(const std::string& file, const int line, const std::stri
 }
 /* *************************************************************** */
 } // namespace NiftyReg::Cuda::Internal
+/* *************************************************************** */
+// CUDA 13 changed the cuCtxCreate signature (now cuCtxCreate_v4), adding a
+// leading CUctxCreateParams* argument. Wrap it to keep a single call site.
+inline CUresult CtxCreate(CUcontext *pctx, const unsigned flags, const CUdevice dev) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13000
+    return cuCtxCreate(pctx, nullptr, flags, dev);
+#else
+    return cuCtxCreate(pctx, flags, dev);
+#endif
+}
+/* *************************************************************** */
+// cudaDeviceProp::clockRate was removed in CUDA 13; query it via the attribute API.
+inline int GetDeviceClockRate(const int device) {
+    int clockRate = 0;
+    cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate, device);
+    return clockRate;
+}
+/* *************************************************************** */
 #define NR_CUDA_SAFE_CALL(call)             { call; NiftyReg::Cuda::Internal::SafeCall(__FILE__, __LINE__, NR_FUNCTION); }
 #define NR_CUDA_CHECK_KERNEL(grid, block)   NiftyReg::Cuda::Internal::CheckKernel(__FILE__, __LINE__, NR_FUNCTION, grid, block)
 /* *************************************************************** */

--- a/reg-lib/cuda/CudaContext.cpp
+++ b/reg-lib/cuda/CudaContext.cpp
@@ -37,7 +37,7 @@ void CudaContext::PickCard(unsigned deviceId = 999) {
     if (deviceId < numDevices) {
         cudaIdx = deviceId;
         NR_CUDA_SAFE_CALL(cudaSetDevice(cudaIdx));
-        NR_CUDA_SAFE_CALL(cuCtxCreate(&cudaContext, CU_CTX_SCHED_SPIN, cudaIdx));
+        NR_CUDA_SAFE_CALL(Cuda::CtxCreate(&cudaContext, CU_CTX_SCHED_SPIN, cudaIdx));
 
         cudaGetDeviceProperties(&deviceProp, cudaIdx);
         if (deviceProp.major > 1) {
@@ -57,7 +57,7 @@ void CudaContext::PickCard(unsigned deviceId = 999) {
     unsigned currentDevice = 0;
     while (currentDevice < numDevices) {
         cudaGetDeviceProperties(&deviceProp, currentDevice);
-        int gflops = deviceProp.multiProcessorCount * deviceProp.clockRate;
+        int gflops = deviceProp.multiProcessorCount * Cuda::GetDeviceClockRate(currentDevice);
         if (gflops > maxGflops) {
             maxGflops = gflops;
             maxGflopsDevice = currentDevice;
@@ -65,7 +65,7 @@ void CudaContext::PickCard(unsigned deviceId = 999) {
         ++currentDevice;
     }
     NR_CUDA_SAFE_CALL(cudaSetDevice(maxGflopsDevice));
-    NR_CUDA_SAFE_CALL(cuCtxCreate(&cudaContext, CU_CTX_SCHED_SPIN, maxGflopsDevice));
+    NR_CUDA_SAFE_CALL(Cuda::CtxCreate(&cudaContext, CU_CTX_SCHED_SPIN, maxGflopsDevice));
     NR_CUDA_SAFE_CALL(cudaGetDeviceProperties(&deviceProp, maxGflopsDevice));
 
     if (deviceProp.major < 1) {
@@ -83,7 +83,7 @@ void CudaContext::PickCard(unsigned deviceId = 999) {
         NR_DEBUG("The CUDA compute capability is " << deviceProp.major << "." << deviceProp.minor);
         NR_DEBUG("The shared memory size in bytes: " << deviceProp.sharedMemPerBlock);
         NR_DEBUG("The CUDA version is " << CUDART_VERSION);
-        NR_DEBUG("The card clock rate is " << deviceProp.clockRate / 1000 << " MHz");
+        NR_DEBUG("The card clock rate is " << Cuda::GetDeviceClockRate(maxGflopsDevice) / 1000 << " MHz");
         NR_DEBUG("The card has " << deviceProp.multiProcessorCount << " multiprocessors");
         cudaIdx = maxGflopsDevice;
         cudaGetDeviceProperties(&deviceProp, cudaIdx);

--- a/reg-lib/cuda/CudaLocalTransformation.cu
+++ b/reg-lib/cuda/CudaLocalTransformation.cu
@@ -140,18 +140,18 @@ double ApproxBendingEnergy(const nifti_image *controlPointImage, const float4 *c
         set_second_order_bspline_basis_values(basis.xx, basis.yy, basis.xy);
 
     thrust::counting_iterator index(0);
-    return thrust::transform_reduce(thrust::device, index, index + controlPointNumber, [=]__device__(const int index) {
+    return thrust::transform_reduce(thrust::device, index, index + controlPointNumber, [=]__device__(const int index) -> double {
         const auto secondDerivative = GetApproxSecondDerivative<is3d, false>(index, controlPointTexture, controlPointImageDims, basis);
         if constexpr (is3d)
-            return (Square(secondDerivative.xx.x) + Square(secondDerivative.xx.y) + Square(secondDerivative.xx.z) +
-                    Square(secondDerivative.yy.x) + Square(secondDerivative.yy.y) + Square(secondDerivative.yy.z) +
-                    Square(secondDerivative.zz.x) + Square(secondDerivative.zz.y) + Square(secondDerivative.zz.z) +
-                    2.f * (Square(secondDerivative.xy.x) + Square(secondDerivative.xy.y) + Square(secondDerivative.xy.z) +
-                           Square(secondDerivative.yz.x) + Square(secondDerivative.yz.y) + Square(secondDerivative.yz.z) +
-                           Square(secondDerivative.xz.x) + Square(secondDerivative.xz.y) + Square(secondDerivative.xz.z)));
+            return (Square(secondDerivative.xx.x) + Square(secondDerivative.yy.x) + Square(secondDerivative.zz.x) +
+                    2.0 * (Square(secondDerivative.xy.x) + Square(secondDerivative.yz.x) + Square(secondDerivative.xz.x)) +
+                    Square(secondDerivative.xx.y) + Square(secondDerivative.yy.y) + Square(secondDerivative.zz.y) +
+                    2.0 * (Square(secondDerivative.xy.y) + Square(secondDerivative.yz.y) + Square(secondDerivative.xz.y)) +
+                    Square(secondDerivative.xx.z) + Square(secondDerivative.yy.z) + Square(secondDerivative.zz.z) +
+                    2.0 * (Square(secondDerivative.xy.z) + Square(secondDerivative.yz.z) + Square(secondDerivative.xz.z)));
         else
-            return (Square(secondDerivative.xx.x) + Square(secondDerivative.xx.y) + Square(secondDerivative.yy.x) +
-                    Square(secondDerivative.yy.y) + 2.f * (Square(secondDerivative.xy.x) + Square(secondDerivative.xy.y)));
+            return (Square(secondDerivative.xx.x) + Square(secondDerivative.yy.x) + 2.0 * secondDerivative.xy.x * secondDerivative.xy.x +
+                    Square(secondDerivative.xx.y) + Square(secondDerivative.yy.y) + 2.0 * secondDerivative.xy.y * secondDerivative.xy.y);
     }, 0.0, thrust::plus<double>()) / static_cast<double>(controlPointImage->nvox);
 }
 template double ApproxBendingEnergy<false>(const nifti_image*, const float4*);
@@ -880,7 +880,7 @@ double ApproxLinearEnergy(const nifti_image *controlPointGrid,
 
     constexpr int matSize = is3d ? 3 : 2;
     thrust::counting_iterator index(0);
-    return thrust::transform_reduce(thrust::device, index, index + voxelNumber, [=]__device__(const int index) {
+    return thrust::transform_reduce(thrust::device, index, index + voxelNumber, [=]__device__(const int index) -> double {
         const mat33 matrix = CreateDisplacementMatrix<is3d>(index, controlPointTexture, cppDims, basis, reorientation);
         double currentValue = 0;
         for (int b = 0; b < matSize; b++)

--- a/reg-lib/cuda/CudaNormaliseGradient.cu
+++ b/reg-lib/cuda/CudaNormaliseGradient.cu
@@ -7,7 +7,7 @@ float GetMaximalLength(const float4 *imageCuda, const size_t nVoxels) {
     auto imageTexturePtr = Cuda::CreateTextureObject(imageCuda, nVoxels, cudaChannelFormatKindFloat, 4);
     auto imageTexture = *imageTexturePtr;
     thrust::counting_iterator<unsigned> index(0);
-    return thrust::transform_reduce(thrust::device, index, index + nVoxels, [=]__device__(const unsigned index) {
+    return thrust::transform_reduce(thrust::device, index, index + nVoxels, [=]__device__(const unsigned index) -> float {
         const float4 val = tex1Dfetch<float4>(imageTexture, index);
         return sqrtf((optimiseX ? Square(val.x) : 0) +
                      (optimiseY ? Square(val.y) : 0) +

--- a/reg-lib/cuda/CudaOptimiser.cu
+++ b/reg-lib/cuda/CudaOptimiser.cu
@@ -238,12 +238,12 @@ void GetConjugateGradient(float4 *gradientCuda,
 
     double gam;
     thrust::counting_iterator<int> it(0);
-    const double2 gg = thrust::transform_reduce(thrust::device, it, it + nVoxels, [=]__device__(const int index) {
+    const double2 gg = thrust::transform_reduce(thrust::device, it, it + nVoxels, [=]__device__(const int index) -> double2 {
         return calcGam(gradientTexture, conjugateGTexture, conjugateHTexture, index);
     }, make_double2(0, 0), thrust::plus<double2>());
     if (isSymmetric) {
         it = thrust::counting_iterator<int>(0);
-        const double2 ggBw = thrust::transform_reduce(thrust::device, it, it + nVoxelsBw, [=]__device__(const int index) {
+        const double2 ggBw = thrust::transform_reduce(thrust::device, it, it + nVoxelsBw, [=]__device__(const int index) -> double2 {
             return calcGam(gradientBwTexture, conjugateGBwTexture, conjugateHBwTexture, index);
         }, make_double2(0, 0), thrust::plus<double2>());
         gam = (gg.x + ggBw.x) / (gg.y + ggBw.y);

--- a/reg-lib/cuda/_reg_cudainfo.cu
+++ b/reg-lib/cuda/_reg_cudainfo.cu
@@ -19,7 +19,7 @@ void showCUDAInfo() {
         cudaGetDeviceProperties(&deviceProp, currentDevice);
         if (deviceProp.major > 0) {
             NR_CUDA_SAFE_CALL(cudaSetDevice(currentDevice));
-            NR_CUDA_SAFE_CALL(cuCtxCreate(&cuContext, CU_CTX_SCHED_SPIN, currentDevice));
+            NR_CUDA_SAFE_CALL(NiftyReg::Cuda::CtxCreate(&cuContext, CU_CTX_SCHED_SPIN, currentDevice));
             NR_COUT << "[NiftyReg CUDA] Device ID: " << currentDevice << std::endl;
             NR_COUT << "[NiftyReg CUDA] Device name: " << deviceProp.name << std::endl;
             size_t free = 0, total = 0;
@@ -28,7 +28,7 @@ void showCUDAInfo() {
             NR_COUT << "[NiftyReg CUDA] Card compute capability: " << deviceProp.major << "." << deviceProp.minor << std::endl;
             NR_COUT << "[NiftyReg CUDA] Shared memory size in bytes: " << deviceProp.sharedMemPerBlock << std::endl;
             NR_COUT << "[NiftyReg CUDA] CUDA version " << CUDART_VERSION << std::endl;
-            NR_COUT << "[NiftyReg CUDA] Card clock rate (Mhz): " << deviceProp.clockRate / 1000 << std::endl;
+            NR_COUT << "[NiftyReg CUDA] Card clock rate (Mhz): " << NiftyReg::Cuda::GetDeviceClockRate(currentDevice) / 1000 << std::endl;
             NR_COUT << "[NiftyReg CUDA] Card has " << deviceProp.multiProcessorCount << " multiprocessor(s)" << std::endl;
         }
         cuCtxDestroy(cuContext);

--- a/reg-lib/cuda/_reg_measure_gpu.h
+++ b/reg-lib/cuda/_reg_measure_gpu.h
@@ -99,6 +99,8 @@ public:
     /// @brief reg_lncc class destructor
     virtual ~reg_lncc_gpu() {}
 
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
                                    float *refImgCuda,
                                    nifti_image *floImg,
@@ -141,6 +143,8 @@ public:
     /// @brief reg_kld_gpu class destructor
     virtual ~reg_kld_gpu() {}
 
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
                                    float *refImgCuda,
                                    nifti_image *floImg,
@@ -183,6 +187,8 @@ public:
     /// @brief reg_dti_gpu class destructor
     virtual ~reg_dti_gpu() {}
 
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
                                    float *refImgCuda,
                                    nifti_image *floImg,

--- a/reg-lib/cuda/_reg_nmi_gpu.cu
+++ b/reg-lib/cuda/_reg_nmi_gpu.cu
@@ -181,7 +181,7 @@ void reg_getNmiValue_gpu(const nifti_image *referenceImage,
         });
         // Compute the entropy of the reference image
         thrust::counting_iterator<unsigned short> it(0);
-        entropyValues[t][0] = thrust::transform_reduce(thrust::device, it, it + curRefBinNumber, [=]__device__(const unsigned short r) {
+        entropyValues[t][0] = thrust::transform_reduce(thrust::device, it, it + curRefBinNumber, [=]__device__(const unsigned short r) -> double {
             const double valPro = jointHistogramProCuda[curRefBinNumber * curFloBinNumber + r];
             if (valPro > 0) {
                 const double valLog = log(valPro);
@@ -191,7 +191,7 @@ void reg_getNmiValue_gpu(const nifti_image *referenceImage,
         }, 0.0, thrust::plus<double>());
         // Compute the entropy of the warped floating image
         it = thrust::counting_iterator<unsigned short>(0);
-        entropyValues[t][1] = thrust::transform_reduce(thrust::device, it, it + curFloBinNumber, [=]__device__(const unsigned short f) {
+        entropyValues[t][1] = thrust::transform_reduce(thrust::device, it, it + curFloBinNumber, [=]__device__(const unsigned short f) -> double {
             const double valPro = jointHistogramProCuda[curRefBinNumber * curFloBinNumber + curRefBinNumber + f];
             if (valPro > 0) {
                 const double valLog = log(valPro);
@@ -201,7 +201,7 @@ void reg_getNmiValue_gpu(const nifti_image *referenceImage,
         }, 0.0, thrust::plus<double>());
         // Compute the joint entropy
         it = thrust::counting_iterator<unsigned short>(0);
-        entropyValues[t][2] = thrust::transform_reduce(thrust::device, it, it + curRefBinNumber * curFloBinNumber, [=]__device__(const unsigned short index) {
+        entropyValues[t][2] = thrust::transform_reduce(thrust::device, it, it + curRefBinNumber * curFloBinNumber, [=]__device__(const unsigned short index) -> double {
             const double valPro = jointHistogramProCuda[index];
             if (valPro > 0) {
                 const double valLog = log(valPro);

--- a/reg-lib/cuda/_reg_nmi_gpu.h
+++ b/reg-lib/cuda/_reg_nmi_gpu.h
@@ -25,6 +25,8 @@ public:
     virtual ~reg_nmi_gpu();
 
     /// @brief Initialise the reg_nmi_gpu object
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
                                    float *refImgCuda,
                                    nifti_image *floImg,
@@ -67,6 +69,8 @@ protected:
 /// @brief NMI measure of similarity class
 class reg_multichannel_nmi_gpu: public reg_multichannel_nmi, public reg_measure_gpu {
 public:
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     void InitialiseMeasure(nifti_image *refImg,
                            float *refImgCuda,
                            nifti_image *floImg,

--- a/reg-lib/cuda/_reg_ssd_gpu.cu
+++ b/reg-lib/cuda/_reg_ssd_gpu.cu
@@ -139,7 +139,7 @@ void reg_getVoxelBasedSsdGradient_gpu(const nifti_image *referenceImage,
     }
 
     // Find number of valid voxels and correct weight
-    const auto validVoxelNumber = thrust::count_if(thrust::device, maskCuda, maskCuda + activeVoxelNumber, [=]__device__(const int index) {
+    const auto validVoxelNumber = thrust::count_if(thrust::device, maskCuda, maskCuda + activeVoxelNumber, [=]__device__(const int index) -> bool {
         const float refValue = tex1Dfetch<float>(referenceTexture, index);
         if (refValue != refValue) return false;
         const float warValue = tex1Dfetch<float>(warpedTexture, index);

--- a/reg-lib/cuda/_reg_ssd_gpu.h
+++ b/reg-lib/cuda/_reg_ssd_gpu.h
@@ -26,6 +26,8 @@ public:
     virtual ~reg_ssd_gpu();
 
     /// @brief Initialise the reg_ssd object
+    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
+    using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
                                    float *refImgCuda,
                                    nifti_image *floImg,

--- a/reg-test/reg_test_blockMatching.cpp
+++ b/reg-test/reg_test_blockMatching.cpp
@@ -175,7 +175,7 @@ TEST_CASE_METHOD(BMTest, "Block Matching", "[unit]") {
                         NR_COUT << "[" << b << "/" << blockMatchingParams->activeBlockNumber << ":" << d << "] ";
                         NR_COUT << diffPos << std::endl;
                     }
-                    REQUIRE(diff < EPS);
+                    REQUIRE(diff == 0);
                 }
             }
         }

--- a/reg-test/reg_test_getDeformationField.cpp
+++ b/reg-test/reg_test_getDeformationField.cpp
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(GetDeformationFieldTest, "Deformation Field from B-spline Grid"
                     NR_COUT << " | Result=" << resVal;
                     NR_COUT << " | Expected=" << expVal << std::endl;
                 }
-                REQUIRE(diff < EPS);
+                REQUIRE(diff == 0);
             }
         }
     }

--- a/reg-test/reg_test_regr_approxBendingEnergyGradient.cpp
+++ b/reg-test/reg_test_regr_approxBendingEnergyGradient.cpp
@@ -144,7 +144,7 @@ TEST_CASE_METHOD(ApproxBendingEnergyGradientTest, "Regression Approximate Bendin
                 const auto diff = abs(cpuVal - cudaVal);
                 if (diff > 0)
                     NR_COUT << i << " " << cpuVal << " " << cudaVal << std::endl;
-                REQUIRE(diff < EPS);
+                REQUIRE(diff == 0);
             }
         }
     }

--- a/reg-test/reg_test_regr_kernelConvolution.cpp
+++ b/reg-test/reg_test_regr_kernelConvolution.cpp
@@ -164,7 +164,7 @@ TEST_CASE_METHOD(KernelConvolutionTest, "Regression Kernel Convolution", "[regre
                 const float diff = fabs(cpuVal - cudaVal);
                 if (diff > EPS)
                     NR_COUT << i << " " << cpuVal << " " << cudaVal << std::endl;
-                REQUIRE(diff < EPS);
+                REQUIRE(diff == 0);
             }
         }
     }

--- a/reg-test/reg_test_voxelCentricToNodeCentric.cpp
+++ b/reg-test/reg_test_voxelCentricToNodeCentric.cpp
@@ -272,7 +272,7 @@ TEST_CASE_METHOD(VoxelCentricToNodeCentricTest, "Voxel Centric to Node Centric",
                     NR_COUT << " | Result=" << transGradVal;
                     NR_COUT << " | Expected=" << expTransGradVal << std::endl;
                 }
-                REQUIRE(diff < EPS);
+                REQUIRE(diff == 0);
             }
         }
     }


### PR DESCRIPTION
Fixes the build under CUDA 13 and on ARM/aarch64 (DGX Spark / GB10), cleans up warnings, and keeps the CPU↔GPU tests bit-exact without sacrificing production FMA performance.
 
CUDA 13
- Add relocated CCCL (include/cccl) headers to the include path.
- Wrap the new cuCtxCreate_v4 signature; replace removed cudaDeviceProp::clockRate with cudaDeviceGetAttribute.
- Add explicit trailing return types to __device__ lambdas now required by CCCL.

ARM / aarch64
- Default USE_SSE off on non-x86.
- Build bundled libpng with PNG_ARM_NEON_OPT=0 (no NEON sources shipped).

Warnings
- Fix ignored fscanf return; silence nvcc #997-D name-hiding via using; add -Wno-psabi (GCC).

CPU/GPU consistency
- New USE_CUDA_FMA CMake flag: defaults off with BUILD_TESTING (FMA off → CPU/GPU bit-exact, tests pass), on otherwise (production performance); overridable.
- Align GPU bending-energy reduction to the CPU order → bit-exact.

Tests
- Tighten 5 now-bit-exact CPU↔GPU checks from < EPS to == 0; keep < EPS only for parallel reductions and reference comparisons.