### PR TITLE
#137 added lncc gpu, optimise convolution, fix backward nmi and ssd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ CMakeSettings.json
 # Build
 build*
 out*
+benchmark
 
 # Doxygen
 html

--- a/reg-apps/reg_benchmark.cpp
+++ b/reg-apps/reg_benchmark.cpp
@@ -33,6 +33,7 @@
 // It also does a quick CPU-vs-CUDA sanity check (flags a NaN mismatch between the platforms).
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
@@ -60,6 +61,7 @@
 #include "Platform.h"            // Platform / Content / Compute / Kernel / NiftiImage / Mat44Eye
 #include "DefContentCreator.h"   // DefContentCreator / DefContent (the NMI value benchmark content)
 #include "_reg_nmi.h"            // reg_nmi (ApproximatePw / SetTimePointWeight; NMI similarity value)
+#include "_reg_lncc.h"           // reg_lncc (SetTimePointWeight; LNCC similarity value, convolution-bound)
 
 using std::unique_ptr;
 using std::vector;
@@ -609,6 +611,114 @@ static void runNmiBenchmarks(Platform& cpu, Platform& cuda, int warmup, int runs
 }
 
 /* ---------------------------------------------------------------------------------------------- */
+// LNCC similarity-value benchmark.
+//
+// Times reg_lncc::GetSimilarityMeasureValue(). Unlike NMI, LNCC is convolution-bound: each call
+// builds the combined mask, then runs five separable Gaussian convolutions (local mean/sdev of the
+// reference and warped, plus the correlation) before the per-voxel reduction. On the CPU the
+// convolutions and the reduction are OpenMP-parallelised; the CUDA path reuses the shared
+// Cuda::KernelConvolution and is bit-identical to the CPU (USE_CUDA_FMA=OFF), so all three columns
+// compute the same thing. Setup mirrors buildNmi and goes through the base Platform virtuals - the
+// CUDA platform produces a CudaDefContent + reg_lncc_gpu automatically.
+//
+// NB: Cuda::KernelConvolution (and its CPU counterpart) hard-fail on any dimension > 2048, so the
+// LNCC sweep caps at 2048 (the NMI 4096 case is intentionally omitted here).
+
+struct LnccBuilt {
+    NiftiImage ref, flo, war;
+    unique_ptr<Content> content;
+    unique_ptr<MeasureCreator> measureCreator;
+    unique_ptr<reg_measure> measure;  // a reg_lncc (reg_lncc_gpu on CUDA), driven via the base pointer
+};
+
+static LnccBuilt buildLncc(Platform& platform, const NiftiImage& reference, const NiftiImage& warped) {
+    LnccBuilt b;
+    b.ref = reference;  // fresh per-platform copies (InitialiseMeasure rescales the reference in place)
+    b.flo = reference;  // floating is required by Create but unused by the value (warped drives it)
+    b.war = warped;
+    unique_ptr<ContentCreator> cc{ platform.CreateContentCreator(ContentType::Def) };
+    auto* defCreator = dynamic_cast<DefContentCreator*>(cc.get());
+    b.content.reset(defCreator->Create(b.ref, b.flo));   // CudaDefContent on the CUDA platform
+    b.content->SetWarped(NiftiImage(b.war));              // uploads host->device on CUDA
+    b.measureCreator.reset(platform.CreateMeasureCreator());
+    b.measure.reset(b.measureCreator->Create(MeasureType::Lncc));  // reg_lncc_gpu on the CUDA platform
+    auto* lncc = dynamic_cast<reg_lncc*>(b.measure.get());
+    for (int t = 0; t < b.ref->nt; ++t)
+        lncc->SetTimePointWeight(t, 1.0);
+    // Default Gaussian kernel, standard deviation -5 (voxel-based) - kept as-is on both platforms.
+    auto* defContent = dynamic_cast<DefContent*>(b.content.get());
+    b.measureCreator->Initialise(*b.measure, *defContent);
+    return b;
+}
+
+// Time one LNCC value computation (2D or 3D, cubic size n) on CPU (1 and max threads) and CUDA.
+static void runLnccBench(bool is3d, int n, Platform& cpu, Platform& cuda,
+                         int warmup, int runs, int maxThreads) {
+    const vector<dim_t> dims = is3d ? vector<dim_t>{ n, n, n } : vector<dim_t>{ n, n };
+    const unsigned seed = static_cast<unsigned>(n) * 2u + (is3d ? 1u : 0u);
+    const NiftiImage reference = makeNmiImage(dims, seed);
+    const NiftiImage warped = makeNmiImage(dims, seed + 100u);
+    const size_t voxels = reference.nVoxels();
+
+    // --- CPU (build once; time at 1 thread, then at max threads) ---
+    LnccBuilt cpuBuilt = buildLncc(cpu, reference, warped);
+#ifdef _OPENMP
+    omp_set_num_threads(1);
+#endif
+    const Stats cpu1 = timeIt(warmup, runs, [&] { cpuBuilt.measure->GetSimilarityMeasureValue(); });
+    const double cpuVal = cpuBuilt.measure->GetSimilarityMeasureValue();
+
+    Stats cpuN;
+#ifdef _OPENMP
+    if (maxThreads > 1) {
+        omp_set_num_threads(maxThreads);
+        cpuN = timeIt(warmup, runs, [&] { cpuBuilt.measure->GetSimilarityMeasureValue(); });
+    }
+    omp_set_num_threads(maxThreads);  // keep the GPU-path host work under the reg_aladin -platf 1 policy
+#endif
+
+    // --- CUDA (build once; the value call runs the device kernels and reduces to the host) ---
+    LnccBuilt gpuBuilt = buildLncc(cuda, reference, warped);
+    const Stats gpu = timeIt(warmup, runs, [&] {
+        gpuBuilt.measure->GetSimilarityMeasureValue();
+        cudaDeviceSynchronize();
+    });
+    const double gpuVal = gpuBuilt.measure->GetSimilarityMeasureValue();
+
+    // --- print one row ---
+    const double cpuNms = cpuN.available ? cpuN.meanMs : cpu1.meanMs;
+    const double ompSpeedup = cpuN.available && cpuN.meanMs > 0 ? cpu1.meanMs / cpuN.meanMs : 0;
+    const double gpuSpeedup = gpu.meanMs > 0 ? cpuNms / gpu.meanMs : 0;
+    const std::string size = is3d ? (std::to_string(n) + "^3") : (std::to_string(n) + "^2");
+    std::printf("%-8s %-10s %12zu %10.3f ", is3d ? "LNCC 3D" : "LNCC 2D", size.c_str(), voxels, cpu1.meanMs);
+    if (cpuN.available) std::printf("%10.3f %8.2fx ", cpuN.meanMs, ompSpeedup);
+    else                std::printf("%10s %9s ", "n/a", "n/a");
+    std::printf("%12.4f %10.2fx\n", gpu.meanMs, gpuSpeedup);
+    // Full-precision values: lets bit-exactness (CPU vs CUDA, and old vs new builds) be checked
+    // from the benchmark output alone.
+    std::printf("  value cpu=%.17g cuda=%.17g diff=%.3g\n", cpuVal, gpuVal, std::fabs(cpuVal - gpuVal));
+    if (std::fabs(cpuVal - gpuVal) > 1e-4)
+        std::printf("  ** WARNING: CPU/CUDA LNCC value diff %.3g (cpu=%.6f cuda=%.6f) **\n",
+                    std::fabs(cpuVal - gpuVal), cpuVal, gpuVal);
+    std::fflush(stdout);
+}
+
+static void runLnccBenchmarks(Platform& cpu, Platform& cuda, int warmup, int runs, int maxThreads) {
+    std::printf("\nLNCC similarity value (reg_lncc::GetSimilarityMeasureValue, default Gaussian kernel)\n");
+    std::printf("Convolution-bound: 5 separable Gaussian smoothings + a per-voxel reduction per call.\n");
+    std::printf("OMPspeedup = CPU-1 / CPU-N; GPUspeedup = CPU-N / GPU. GPU includes device sync.\n");
+    std::printf("%-8s %-10s %12s %10s %10s %8s %12s %10s\n",
+                "measure", "size", "voxels", "CPU-1", "CPU-N", "OMPspd", "GPU", "GPUspd");
+    std::printf("%-8s %-10s %12s %10s %10s %8s %12s %10s\n",
+                "-------", "----", "------", "-----", "-----", "------", "---", "------");
+    // KernelConvolution rejects any dimension > 2048, so the sweep stays at or below 2048.
+    const vector<int> sizes3d = { 64, 128, 256 };
+    const vector<int> sizes2d = { 512, 1024, 2048 };
+    for (int n : sizes3d) runLnccBench(/*is3d*/true, n, cpu, cuda, warmup, runs, maxThreads);
+    for (int n : sizes2d) runLnccBench(/*is3d*/false, n, cpu, cuda, warmup, runs, maxThreads);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
 
 int main(int argc, char** argv) {
     int runs = 10, warmup = 2;
@@ -616,20 +726,41 @@ int main(int argc, char** argv) {
     // 3D and 2D cubic sizes to sweep (kept moderate; edit here to change the sweep).
     vector<int> sizes3d = {32, 128, 256};
     vector<int> sizes2d = {128, 1024, 4096};
+    // Which benchmark(s) to run. Empty = all. One of: resample, lts, nmi, lncc.
+    std::string only;
+    const char* kernelNames[] = { "resample", "lts", "nmi", "lncc" };
 
     for (int i = 1; i < argc; ++i) {
         if (!std::strcmp(argv[i], "-n") && i + 1 < argc) runs = std::atoi(argv[++i]);
         else if (!std::strcmp(argv[i], "-w") && i + 1 < argc) warmup = std::atoi(argv[++i]);
         else if ((!std::strcmp(argv[i], "-gpuid") || !std::strcmp(argv[i], "--gpuid")) && i + 1 < argc)
             gpuIdx = static_cast<unsigned>(std::atoi(argv[++i]));
-        else if (!std::strcmp(argv[i], "-h") || !std::strcmp(argv[i], "--help")) {
-            std::printf("Usage: %s [-n timed_runs] [-w warmup_runs] [-gpuid <int>]\n", argv[0]);
-            std::printf("  Benchmarks 2D and 3D linear resampling on CPU (1 and max threads) vs CUDA,\n");
-            std::printf("  then the LTS affine/rigid estimator (CPU thread-scaling + CUDA-path scaffolding).\n");
-            std::printf("  -gpuid <int>  Id of the GPU card to use [automatic]\n");
+        else if ((!std::strcmp(argv[i], "-only") || !std::strcmp(argv[i], "--only") || !std::strcmp(argv[i], "-k")) && i + 1 < argc) {
+            only = argv[++i];
+            for (char& c : only) c = static_cast<char>(std::tolower(c));
+        } else if (!std::strcmp(argv[i], "-h") || !std::strcmp(argv[i], "--help")) {
+            std::printf("Usage: %s [-n timed_runs] [-w warmup_runs] [-gpuid <int>] [-only <kernel>]\n", argv[0]);
+            std::printf("  Benchmarks (in order) 2D/3D linear resampling, the LTS affine/rigid estimator,\n");
+            std::printf("  the NMI similarity value, and the LNCC similarity value, on CPU (1 and max\n");
+            std::printf("  threads) vs CUDA.\n");
+            std::printf("  -gpuid <int>     Id of the GPU card to use [automatic]\n");
+            std::printf("  -only <kernel>   Run only one benchmark: resample | lts | nmi | lncc [all]\n");
+            std::printf("                   (aliases: -k, --only)\n");
             return 0;
+        } else {
+            // Fail loudly on unknown/misplaced arguments rather than silently ignoring them
+            // (a silent ignore of -only would run every kernel, which is confusing).
+            std::fprintf(stderr, "Unknown or incomplete argument '%s'. Use -h for usage.\n", argv[i]);
+            return 1;
         }
     }
+
+    // Validate the -only selection early so a typo fails before the CUDA context is created.
+    if (!only.empty() && std::find(std::begin(kernelNames), std::end(kernelNames), only) == std::end(kernelNames)) {
+        std::fprintf(stderr, "Unknown -only kernel '%s'. Valid values: resample, lts, nmi, lncc.\n", only.c_str());
+        return 1;
+    }
+    const auto shouldRun = [&](const char* name) { return only.empty() || only == name; };
 
     int maxThreads = 1;
 #ifdef _OPENMP
@@ -665,25 +796,38 @@ int main(int argc, char** argv) {
     std::printf("all timings are means in ms. GPU(kernel) = kernel only; GPU(+copy) adds the device->host\n");
     std::printf("download; GPU(app) = alloc + upload + kernel + download per call. A one-shot GPU run's\n");
     std::printf("latency ~ %.1f ms (init) + GPU(app).\n\n", cudaInitMs);
-    std::printf("%-20s %-18s %10s %10s %12s %12s %12s %11s\n",
-                "operation", "size", "CPU-1", "CPU-N", "GPU(kernel)", "GPU(+copy)", "GPU(app)", "speedup");
-    std::printf("%-20s %-18s %10s %10s %12s %12s %12s %11s\n",
-                "---------", "----", "-----", "-----", "-----------", "----------", "--------", "-------");
+    if (!only.empty())
+        std::printf("running only: %s\n", only.c_str());
 
-    // The functionality list. Extend by pushing more tasks (e.g. gradient, spline) here; runTask
-    // handles any BenchmarkTask uniformly.
-    vector<BenchmarkTask> tasks;
-    for (int n : sizes3d) tasks.push_back(makeResampleTask(/*is3d*/true, n));
-    for (int n : sizes2d) tasks.push_back(makeResampleTask(/*is3d*/false, n));
+    // Resampling: 2D/3D linear resampling. Its column layout is specific to this section, so the
+    // table header is printed here (the other sections print their own headers).
+    if (shouldRun("resample")) {
+        std::printf("%-20s %-18s %10s %10s %12s %12s %12s %11s\n",
+                    "operation", "size", "CPU-1", "CPU-N", "GPU(kernel)", "GPU(+copy)", "GPU(app)", "speedup");
+        std::printf("%-20s %-18s %10s %10s %12s %12s %12s %11s\n",
+                    "---------", "----", "-----", "-----", "-----------", "----------", "--------", "-------");
 
-    for (const BenchmarkTask& task : tasks)
-        runTask(task, cpu, cuda, warmup, runs, maxThreads);
+        // The functionality list. Extend by pushing more tasks (e.g. gradient, spline) here; runTask
+        // handles any BenchmarkTask uniformly.
+        vector<BenchmarkTask> tasks;
+        for (int n : sizes3d) tasks.push_back(makeResampleTask(/*is3d*/true, n));
+        for (int n : sizes2d) tasks.push_back(makeResampleTask(/*is3d*/false, n));
+
+        for (const BenchmarkTask& task : tasks)
+            runTask(task, cpu, cuda, warmup, runs, maxThreads);
+    }
 
     // LTS (reg_aladin affine/rigid fit): CPU thread-scaling + the CUDA-path baseline (scaffolding).
-    runLtsBenchmarks(cpu, cuda, warmup, runs, maxThreads);
+    if (shouldRun("lts"))
+        runLtsBenchmarks(cpu, cuda, warmup, runs, maxThreads);
 
     // NMI similarity value: CPU 1-thread vs N-threads (the OpenMP win) vs CUDA.
-    runNmiBenchmarks(cpu, cuda, warmup, runs, maxThreads);
+    if (shouldRun("nmi"))
+        runNmiBenchmarks(cpu, cuda, warmup, runs, maxThreads);
+
+    // LNCC similarity value: convolution-bound CPU thread-scaling vs the new CUDA port.
+    if (shouldRun("lncc"))
+        runLnccBenchmarks(cpu, cuda, warmup, runs, maxThreads);
 
     return 0;
 }

--- a/reg-lib/Compute.cpp
+++ b/reg-lib/Compute.cpp
@@ -5,6 +5,8 @@
 #include "_reg_localTrans_regul.h"
 
 /* *************************************************************** */
+Compute::~Compute() = default;
+/* *************************************************************** */
 void Compute::ResampleImage(int interpolation, float paddingValue) {
     reg_resampleImage(con.GetFloating(),
                       con.GetWarped(),

--- a/reg-lib/Compute.cpp
+++ b/reg-lib/Compute.cpp
@@ -5,8 +5,6 @@
 #include "_reg_localTrans_regul.h"
 
 /* *************************************************************** */
-Compute::~Compute() = default;
-/* *************************************************************** */
 void Compute::ResampleImage(int interpolation, float paddingValue) {
     reg_resampleImage(con.GetFloating(),
                       con.GetWarped(),

--- a/reg-lib/Compute.cpp
+++ b/reg-lib/Compute.cpp
@@ -230,36 +230,18 @@ void Compute::GetDefFieldFromVelocityGrid(const bool updateStepNumber) {
 void Compute::ConvolveImage(NiftiImage& image) {
     const NiftiImage& controlPointGrid = dynamic_cast<F3dContent&>(con).F3dContent::GetControlPointGrid();
     constexpr ConvKernelType kernelType = ConvKernelType::Cubic;
-    float currentNodeSpacing[3];
-    currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dx;
-    bool activeAxis[3] = { 1, 0, 0 };
-    reg_tools_kernelConvolution(image,
-                                currentNodeSpacing,
-                                kernelType,
-                                nullptr, // mask
-                                nullptr, // all volumes are considered as active
-                                activeAxis);
-    // Convolution along the y axis
-    currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dy;
-    activeAxis[0] = 0;
-    activeAxis[1] = 1;
-    reg_tools_kernelConvolution(image,
-                                currentNodeSpacing,
-                                kernelType,
-                                nullptr, // mask
-                                nullptr, // all volumes are considered as active
-                                activeAxis);
-    // Convolution along the z axis if required
-    if (image->nz > 1) {
-        currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dz;
-        activeAxis[1] = 0;
-        activeAxis[2] = 1;
-        reg_tools_kernelConvolution(image,
-                                    currentNodeSpacing,
-                                    kernelType,
-                                    nullptr, // mask
-                                    nullptr, // all volumes are considered as active
-                                    activeAxis);
+    // Reuse the workspace so the per-axis passes pool their scratch. The density is recomputed each pass:
+    // every axis renormalises by its own smoothed density, so it is NOT shared across passes.
+    convWorkspace.useFloatAccumulation = true;
+    const float nodeSpacings[3]{ controlPointGrid->dx, controlPointGrid->dy, controlPointGrid->dz };
+    const int axisCount = image->nz > 1 ? 3 : 2;
+    for (int axis = 0; axis < axisCount; ++axis) {
+        float currentNodeSpacing[3];
+        currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = nodeSpacings[axis];
+        bool activeAxis[3]{ axis == 0, axis == 1, axis == 2 };
+        convWorkspace.densityValid = false; // recompute the density for this pass
+        reg_tools_kernelConvolution(image, currentNodeSpacing, kernelType,
+                                    nullptr, nullptr, activeAxis, &convWorkspace);
     }
 }
 /* *************************************************************** */

--- a/reg-lib/Compute.h
+++ b/reg-lib/Compute.h
@@ -2,6 +2,7 @@
 
 #include "Content.h"
 #include "Optimiser.hpp"
+#include "_reg_tools.h"
 
 class Compute {
 public:
@@ -46,4 +47,6 @@ public:
 private:
     void ConvolveImage(NiftiImage&);
     NiftiImage ScaleGradient(const NiftiImage&, float);
+    // Reusable scratch for the voxel-based-gradient smoothing convolutions
+    ConvolutionWorkspace convWorkspace;
 };

--- a/reg-lib/Compute.h
+++ b/reg-lib/Compute.h
@@ -8,6 +8,7 @@ class Compute {
 public:
     Compute() = delete;
     Compute(Content& conIn): con(conIn) {}
+    virtual ~Compute();
 
     virtual void ResampleImage(int interpolation, float paddingValue);
     virtual double GetJacobianPenaltyTerm(bool approx);

--- a/reg-lib/Compute.h
+++ b/reg-lib/Compute.h
@@ -8,7 +8,7 @@ class Compute {
 public:
     Compute() = delete;
     Compute(Content& conIn): con(conIn) {}
-    virtual ~Compute();
+    virtual ~Compute() = default;
 
     virtual void ResampleImage(int interpolation, float paddingValue);
     virtual double GetJacobianPenaltyTerm(bool approx);

--- a/reg-lib/cpu/_reg_lncc.cpp
+++ b/reg-lib/cpu/_reg_lncc.cpp
@@ -34,6 +34,10 @@ reg_lncc::reg_lncc(): reg_measure() {
     for (int i = 0; i < 255; ++i)
         kernelStandardDeviation[i] = -5.f;
 
+    // Accumulate the local convolutions in float rather than double.
+    this->forwardConvWorkspace.useFloatAccumulation = true;
+    this->backwardConvWorkspace.useFloatAccumulation = true;
+
     NR_FUNC_CALLED();
 }
 /* *************************************************************** */
@@ -202,7 +206,8 @@ void UpdateLocalStatImages(const nifti_image *refImage,
                            int *combinedMask,
                            const float *kernelStandardDeviation,
                            const ConvKernelType kernelType,
-                           const int currentTimePoint) {
+                           const int currentTimePoint,
+                           ConvolutionWorkspace *workspace) {
     // Generate the combined mask to ignore all NaN values
 #ifdef _WIN32
     long voxel;
@@ -211,29 +216,56 @@ void UpdateLocalStatImages(const nifti_image *refImage,
     size_t voxel;
     const size_t voxelNumber = NiftiImage::calcVoxelNumber(refImage, 3);
 #endif
-    memcpy(combinedMask, refMask, voxelNumber * sizeof(int));
-    reg_tools_removeNanFromMask(refImage, combinedMask);
-    reg_tools_removeNanFromMask(warImage, combinedMask);
+    // The combined mask (hence the smoothed density) is the same for every convolution below and
+    // for the correlation/gradient convolutions that follow, so force the first convolution to
+    // compute the density and let the rest reuse it.
+    if (workspace) workspace->densityValid = false;
 
     const DataType *origRefPtr = static_cast<DataType*>(refImage->data);
+    const DataType *origWarPtr = static_cast<DataType*>(warImage->data);
+    const DataType *currentRefPtr = &origRefPtr[currentTimePoint * voxelNumber];
+    const DataType *currentWarPtr = &origWarPtr[currentTimePoint * voxelNumber];
     DataType *meanImgPtr = static_cast<DataType*>(meanImage->data);
     DataType *sdevImgPtr = static_cast<DataType*>(sdevImage->data);
-    memcpy(meanImgPtr, &origRefPtr[currentTimePoint * voxelNumber], voxelNumber * refImage->nbyper);
-    memcpy(sdevImgPtr, &origRefPtr[currentTimePoint * voxelNumber], voxelNumber * refImage->nbyper);
-
-    reg_tools_multiplyImageToImage(sdevImage, sdevImage, sdevImage);
-    reg_tools_kernelConvolution(meanImage, kernelStandardDeviation, kernelType, combinedMask);
-    reg_tools_kernelConvolution(sdevImage, kernelStandardDeviation, kernelType, combinedMask);
-
-    const DataType *origWarPtr = static_cast<DataType*>(warImage->data);
     DataType *warMeanPtr = static_cast<DataType*>(warpedMeanImage->data);
     DataType *warSdevPtr = static_cast<DataType*>(warpedSdevImage->data);
-    memcpy(warMeanPtr, &origWarPtr[currentTimePoint * voxelNumber], voxelNumber * warImage->nbyper);
-    memcpy(warSdevPtr, &origWarPtr[currentTimePoint * voxelNumber], voxelNumber * warImage->nbyper);
+    const int maskTimePoints = refImage->nt;
 
-    reg_tools_multiplyImageToImage(warpedSdevImage, warpedSdevImage, warpedSdevImage);
-    reg_tools_kernelConvolution(warpedMeanImage, kernelStandardDeviation, kernelType, combinedMask);
-    reg_tools_kernelConvolution(warpedSdevImage, kernelStandardDeviation, kernelType, combinedMask);
+    // One fused parallel pass replacing { memcpy(combinedMask) + 2x reg_tools_removeNanFromMask +
+    // 4x memcpy + 2x reg_tools_multiplyImageToImage }, several of which were serial. Elementwise
+    // identical: the NaN scan covers every time point exactly like reg_tools_removeNanFromMask,
+    // and the squaring matches reg_tools_multiplyImageToImage because the scratch images inherit
+    // scl_slope = 1 / scl_inter = 0 from the rescaled reference (the double-precision product of
+    // two DataType values rounds to the same DataType result as the direct product).
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+    shared(voxelNumber, refMask, combinedMask, origRefPtr, origWarPtr, currentRefPtr, currentWarPtr, \
+    meanImgPtr, sdevImgPtr, warMeanPtr, warSdevPtr, maskTimePoints)
+#endif
+    for (voxel = 0; voxel < voxelNumber; ++voxel) {
+        int maskValue = refMask[voxel];
+        for (int t = 0; t < maskTimePoints; ++t) {
+            const DataType refValue = origRefPtr[t * voxelNumber + voxel];
+            const DataType warValue = origWarPtr[t * voxelNumber + voxel];
+            if (refValue != refValue || warValue != warValue) {
+                maskValue = -1;
+                break;
+            }
+        }
+        combinedMask[voxel] = maskValue;
+        const DataType refVal = currentRefPtr[voxel];
+        const DataType warVal = currentWarPtr[voxel];
+        meanImgPtr[voxel] = refVal;
+        sdevImgPtr[voxel] = refVal * refVal;
+        warMeanPtr[voxel] = warVal;
+        warSdevPtr[voxel] = warVal * warVal;
+    }
+
+    // Smooth the four statistic images in a single multi-image sweep (bit-identical per image to
+    // four sequential convolutions; the density is computed once from the mean image, exactly as
+    // it was by the first of the four convolutions before)
+    nifti_image *statImages[4]{ meanImage, sdevImage, warpedMeanImage, warpedSdevImage };
+    reg_tools_kernelConvolutionMulti(statImages, 4, kernelStandardDeviation, kernelType, combinedMask, workspace);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     shared(voxelNumber, sdevImgPtr, meanImgPtr, warSdevPtr, warMeanPtr)
@@ -259,7 +291,8 @@ double reg_getLnccValue(const nifti_image *referenceImage,
                         const float *kernelStandardDeviation,
                         nifti_image *correlationImage,
                         const ConvKernelType kernelType,
-                        const int currentTimePoint) {
+                        const int currentTimePoint,
+                        ConvolutionWorkspace *workspace) {
 #ifdef _WIN32
     long voxel;
     const long voxelNumber = (long)NiftiImage::calcVoxelNumber(referenceImage, 3);
@@ -280,10 +313,14 @@ double reg_getLnccValue(const nifti_image *referenceImage,
     const DataType *warSdevPtr = static_cast<DataType*>(warpedSdevImage->data);
     DataType *correlationPtr = static_cast<DataType*>(correlationImage->data);
 
-    for (size_t i = 0; i < voxelNumber; ++i)
-        correlationPtr[i] = currentRefPtr[i] * currentWarPtr[i];
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+    shared(voxelNumber, correlationPtr, currentRefPtr, currentWarPtr)
+#endif
+    for (voxel = 0; voxel < voxelNumber; ++voxel)
+        correlationPtr[voxel] = currentRefPtr[voxel] * currentWarPtr[voxel];
 
-    reg_tools_kernelConvolution(correlationImage, kernelStandardDeviation, kernelType, combinedMask);
+    reg_tools_kernelConvolution(correlationImage, kernelStandardDeviation, kernelType, combinedMask, nullptr, nullptr, workspace);
 
     double lnccSum = 0;
     size_t activeVoxelNumber = 0;
@@ -320,7 +357,8 @@ double GetSimilarityMeasureValue(const nifti_image *referenceImage,
                                  nifti_image *correlationImage,
                                  const ConvKernelType kernelType,
                                  const int referenceTimePoints,
-                                 const double *timePointWeights) {
+                                 const double *timePointWeights,
+                                 ConvolutionWorkspace *workspace) {
     double lncc = 0;
     for (int currentTimePoint = 0; currentTimePoint < referenceTimePoints; ++currentTimePoint) {
         if (timePointWeights[currentTimePoint] > 0) {
@@ -337,7 +375,8 @@ double GetSimilarityMeasureValue(const nifti_image *referenceImage,
                                                       forwardMask,
                                                       kernelStandardDeviation,
                                                       kernelType,
-                                                      currentTimePoint);
+                                                      currentTimePoint,
+                                                      workspace);
                 // Compute the LNCC value
                 return reg_getLnccValue<RefImgDataType>(referenceImage,
                                                         meanImage,
@@ -349,7 +388,8 @@ double GetSimilarityMeasureValue(const nifti_image *referenceImage,
                                                         kernelStandardDeviation,
                                                         correlationImage,
                                                         kernelType,
-                                                        currentTimePoint);
+                                                        currentTimePoint,
+                                                        workspace);
             }, NiftiImage::getFloatingDataType(referenceImage));
             lncc += tp * timePointWeights[currentTimePoint];
         }
@@ -370,7 +410,8 @@ double reg_lncc::GetSimilarityMeasureValueFw() {
                                        this->correlationImage,
                                        this->kernelType,
                                        this->referenceTimePoints,
-                                       this->timePointWeights);
+                                       this->timePointWeights,
+                                       &this->forwardConvWorkspace);
 }
 /* *************************************************************** */
 double reg_lncc::GetSimilarityMeasureValueBw() {
@@ -386,7 +427,8 @@ double reg_lncc::GetSimilarityMeasureValueBw() {
                                        this->correlationImageBw,
                                        this->kernelType,
                                        this->referenceTimePoints,
-                                       this->timePointWeights);
+                                       this->timePointWeights,
+                                       &this->backwardConvWorkspace);
 }
 /* *************************************************************** */
 template <class DataType>
@@ -403,7 +445,8 @@ void reg_getVoxelBasedLnccGradient(const nifti_image *referenceImage,
                                    nifti_image *measureGradient,
                                    const ConvKernelType kernelType,
                                    const int currentTimePoint,
-                                   const double timePointWeight) {
+                                   const double timePointWeight,
+                                   ConvolutionWorkspace *workspace) {
 #ifdef _WIN32
     long voxel;
     long voxelNumber = (long)NiftiImage::calcVoxelNumber(referenceImage, 3);
@@ -424,10 +467,14 @@ void reg_getVoxelBasedLnccGradient(const nifti_image *referenceImage,
     DataType *warSdevPtr = static_cast<DataType*>(warpedSdevImage->data);
     DataType *correlationPtr = static_cast<DataType*>(correlationImage->data);
 
-    for (size_t i = 0; i < voxelNumber; ++i)
-        correlationPtr[i] = currentRefPtr[i] * currentWarPtr[i];
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+    shared(voxelNumber, correlationPtr, currentRefPtr, currentWarPtr)
+#endif
+    for (voxel = 0; voxel < voxelNumber; ++voxel)
+        correlationPtr[voxel] = currentRefPtr[voxel] * currentWarPtr[voxel];
 
-    reg_tools_kernelConvolution(correlationImage, kernelStandardDeviation, kernelType, combinedMask);
+    reg_tools_kernelConvolution(correlationImage, kernelStandardDeviation, kernelType, combinedMask, nullptr, nullptr, workspace);
 
     size_t activeVoxelNumber = 0;
 
@@ -470,10 +517,10 @@ void reg_getVoxelBasedLnccGradient(const nifti_image *referenceImage,
     //adjust weight for number of voxels
     const double adjustedWeight = timePointWeight / activeVoxelNumber;
 
-    // Smooth the newly computed values
-    reg_tools_kernelConvolution(warpedMeanImage, kernelStandardDeviation, kernelType, combinedMask);
-    reg_tools_kernelConvolution(warpedSdevImage, kernelStandardDeviation, kernelType, combinedMask);
-    reg_tools_kernelConvolution(correlationImage, kernelStandardDeviation, kernelType, combinedMask);
+    // Smooth the newly computed values in one multi-image sweep (bit-identical per image to three
+    // sequential convolutions; the cached density is reused)
+    nifti_image *tempImages[3]{ warpedMeanImage, warpedSdevImage, correlationImage };
+    reg_tools_kernelConvolutionMulti(tempImages, 3, kernelStandardDeviation, kernelType, combinedMask, workspace);
     DataType *measureGradPtrX = static_cast<DataType*>(measureGradient->data);
     DataType *measureGradPtrY = &measureGradPtrX[voxelNumber];
     DataType *measureGradPtrZ = referenceImage->nz > 1 ? &measureGradPtrY[voxelNumber] : nullptr;
@@ -531,7 +578,8 @@ void GetVoxelBasedSimilarityMeasureGradient(const nifti_image *referenceImage,
                                             nifti_image *measureGradient,
                                             const ConvKernelType kernelType,
                                             const int currentTimePoint,
-                                            const double timePointWeight) {
+                                            const double timePointWeight,
+                                            ConvolutionWorkspace *workspace) {
     std::visit([&](auto&& refImgDataType) {
         using RefImgDataType = std::decay_t<decltype(refImgDataType)>;
         // Compute the mean and variance of the reference and warped floating
@@ -545,7 +593,8 @@ void GetVoxelBasedSimilarityMeasureGradient(const nifti_image *referenceImage,
                                               forwardMask,
                                               kernelStandardDeviation,
                                               kernelType,
-                                              currentTimePoint);
+                                              currentTimePoint,
+                                              workspace);
         // Compute the LNCC gradient
         reg_getVoxelBasedLnccGradient<RefImgDataType>(referenceImage,
                                                       meanImage,
@@ -560,7 +609,8 @@ void GetVoxelBasedSimilarityMeasureGradient(const nifti_image *referenceImage,
                                                       measureGradient,
                                                       kernelType,
                                                       currentTimePoint,
-                                                      timePointWeight);
+                                                      timePointWeight,
+                                                      workspace);
     }, NiftiImage::getFloatingDataType(referenceImage));
 }
 /* *************************************************************** */
@@ -579,7 +629,8 @@ void reg_lncc::GetVoxelBasedSimilarityMeasureGradientFw(int currentTimePoint) {
                                              this->voxelBasedGradient,
                                              this->kernelType,
                                              currentTimePoint,
-                                             this->timePointWeights[currentTimePoint]);
+                                             this->timePointWeights[currentTimePoint],
+                                             &this->forwardConvWorkspace);
 }
 /* *************************************************************** */
 void reg_lncc::GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint) {
@@ -597,6 +648,7 @@ void reg_lncc::GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint) {
                                              this->voxelBasedGradientBw,
                                              this->kernelType,
                                              currentTimePoint,
-                                             this->timePointWeights[currentTimePoint]);
+                                             this->timePointWeights[currentTimePoint],
+                                             &this->backwardConvWorkspace);
 }
 /* *************************************************************** */

--- a/reg-lib/cpu/_reg_lncc.h
+++ b/reg-lib/cpu/_reg_lncc.h
@@ -68,5 +68,9 @@ protected:
     int *backwardMask;
 
     ConvKernelType kernelType;
+
+    // Reusable convolution scratch
+    ConvolutionWorkspace forwardConvWorkspace;
+    ConvolutionWorkspace backwardConvWorkspace;
 };
 /* *************************************************************** */

--- a/reg-lib/cpu/_reg_localTrans.cpp
+++ b/reg-lib/cpu/_reg_localTrans.cpp
@@ -2240,7 +2240,8 @@ void reg_spline_refineControlPointGrid(nifti_image *controlPointGrid,
 template <class DataType>
 void reg_defField_compose2D(const nifti_image *deformationField,
                             nifti_image *dfToUpdate,
-                            const int *mask) {
+                            const int *mask,
+                            const nifti_image *positionField = nullptr) {
     const size_t dfVoxelNumber = NiftiImage::calcVoxelNumber(deformationField, 2);
 #ifdef _WIN32
     long i;
@@ -2251,6 +2252,11 @@ void reg_defField_compose2D(const nifti_image *deformationField,
 #endif
     const DataType *defPtrX = static_cast<DataType*>(deformationField->data);
     const DataType *defPtrY = &defPtrX[dfVoxelNumber];
+
+    // See reg_defField_compose3D: positions come from positionField (ping-pong) or dfToUpdate
+    // (in-place); positionField shares dfToUpdate's geometry, so the result is identical.
+    const DataType *posPtrX = static_cast<DataType*>((positionField ? positionField : dfToUpdate)->data);
+    const DataType *posPtrY = &posPtrX[warVoxelNumber];
 
     DataType *resPtrX = static_cast<DataType*>(dfToUpdate->data);
     DataType *resPtrY = &resPtrX[warVoxelNumber];
@@ -2272,14 +2278,14 @@ void reg_defField_compose2D(const nifti_image *deformationField,
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
    shared(warVoxelNumber, mask, df_real2Voxel, df_voxel2Real, \
-   deformationField, defPtrX, defPtrY, resPtrX, resPtrY) \
+   deformationField, defPtrX, defPtrY, posPtrX, posPtrY, resPtrX, resPtrY) \
    private(a, b, index, pre,realDefX, realDefY, voxelX, voxelY, \
    defX, defY, relX, relY, basis)
 #endif
     for (i = 0; i < warVoxelNumber; ++i) {
         if (mask[i] > -1) {
-            realDefX = resPtrX[i];
-            realDefY = resPtrY[i];
+            realDefX = posPtrX[i];
+            realDefY = posPtrY[i];
 
             // Conversion from real to voxel in the deformation field
             voxelX =
@@ -2333,7 +2339,8 @@ void reg_defField_compose2D(const nifti_image *deformationField,
 template <class DataType>
 void reg_defField_compose3D(const nifti_image *deformationField,
                             nifti_image *dfToUpdate,
-                            const int *mask) {
+                            const int *mask,
+                            const nifti_image *positionField = nullptr) {
     const size_t dfVoxelNumber = NiftiImage::calcVoxelNumber(deformationField, 3);
 #ifdef _WIN32
     long i;
@@ -2345,6 +2352,15 @@ void reg_defField_compose3D(const nifti_image *deformationField,
     const DataType *defPtrX = static_cast<DataType*>(deformationField->data);
     const DataType *defPtrY = &defPtrX[dfVoxelNumber];
     const DataType *defPtrZ = &defPtrY[dfVoxelNumber];
+
+    // Positions to look up: normally the field being updated (in-place composition). When a
+    // separate positionField is supplied (the scaling-and-squaring ping-pong), the positions are
+    // read from it and the result written to dfToUpdate, so source and destination never alias.
+    // positionField shares dfToUpdate's geometry, so the arithmetic is identical to the in-place
+    // case where positionField == dfToUpdate.
+    const DataType *posPtrX = static_cast<DataType*>((positionField ? positionField : dfToUpdate)->data);
+    const DataType *posPtrY = &posPtrX[warVoxelNumber];
+    const DataType *posPtrZ = &posPtrY[warVoxelNumber];
 
     DataType *resPtrX = static_cast<DataType*>(dfToUpdate->data);
     DataType *resPtrY = &resPtrX[warVoxelNumber];
@@ -2372,16 +2388,16 @@ void reg_defField_compose3D(const nifti_image *deformationField,
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
    shared(warVoxelNumber, mask, df_real2Voxel, df_voxel2Real, \
-   defPtrX, defPtrY, defPtrZ, resPtrX, resPtrY, resPtrZ, deformationField) \
+   defPtrX, defPtrY, defPtrZ, posPtrX, posPtrY, posPtrZ, resPtrX, resPtrY, resPtrZ, deformationField) \
    private(a, b, c, currentX, currentY, currentZ, index, tempIndex, pre, \
    realDef, voxel, tempBasis, defX, defY, defZ, relX, relY, relZ, basis, inY, inZ)
 #endif
     for (i = 0; i < warVoxelNumber; ++i) {
         if (mask[i] > -1) {
             // Conversion from real to voxel in the deformation field
-            realDef[0] = resPtrX[i];
-            realDef[1] = resPtrY[i];
-            realDef[2] = resPtrZ[i];
+            realDef[0] = posPtrX[i];
+            realDef[1] = posPtrY[i];
+            realDef[2] = posPtrZ[i];
             voxel[0] =
                 df_real2Voxel.m[0][0] * realDef[0] +
                 df_real2Voxel.m[0][1] * realDef[1] +
@@ -2459,7 +2475,8 @@ void reg_defField_compose3D(const nifti_image *deformationField,
 /* *************************************************************** */
 void reg_defField_compose(const nifti_image *deformationField,
                           nifti_image *dfToUpdate,
-                          const int *mask) {
+                          const int *mask,
+                          const nifti_image *positionField) {
     if (deformationField->datatype != dfToUpdate->datatype)
         NR_FATAL_ERROR("Both deformation fields are expected to have the same type");
 
@@ -2472,7 +2489,7 @@ void reg_defField_compose(const nifti_image *deformationField,
     std::visit([&](auto&& defFieldDataType) {
         using DefFieldDataType = std::decay_t<decltype(defFieldDataType)>;
         auto defFieldCompose = dfToUpdate->nu == 2 ? reg_defField_compose2D<DefFieldDataType> : reg_defField_compose3D<DefFieldDataType>;
-        defFieldCompose(deformationField, dfToUpdate, mask);
+        defFieldCompose(deformationField, dfToUpdate, mask, positionField);
     }, NiftiImage::getFloatingDataType(deformationField));
 }
 /* *************************************************************** */
@@ -3553,21 +3570,22 @@ void reg_defField_getDeformationFieldFromFlowField(nifti_image *flowField,
     // Conversion from displacement to deformation
     reg_getDeformationFromDisplacement(flowField);
 
-    // The computed scaled deformation field is copied over
-    memcpy(deformationField->data, flowField->data,
-           deformationField->nvox * deformationField->nbyper);
-
-    // The deformation field is squared
+    // The deformation field is squared. Ping-pong between the two existing buffers:
+    nifti_image *curField = flowField;          // holds the current (scaled, then squared) field
+    nifti_image *nextField = deformationField;  // receives the next squared field
     for (unsigned short i = 0; i < squaringNumber; ++i) {
-        // The deformation field is applied to itself
-        reg_defField_compose(deformationField,
-                             flowField,
-                             nullptr);
-        // The computed scaled deformation field is copied over
-        memcpy(deformationField->data, flowField->data,
-               deformationField->nvox * deformationField->nbyper);
+        // nextField = curField(curField)
+        reg_defField_compose(curField,   // lookup table
+                             nextField,  // output
+                             nullptr,
+                             curField);  // positions
+        std::swap(curField, nextField);
         NR_DEBUG("Squaring (composition) step " << i + 1 << "/" << squaringNumber);
     }
+    // Ensure the result ends up in deformationField (one copy at most, vs one per step above)
+    if (curField != deformationField)
+        memcpy(deformationField->data, curField->data,
+               deformationField->nvox * deformationField->nbyper);
     // The affine conponent of the transformation is restored
     if (affineOnly) {
         reg_getDisplacementFromDeformation(deformationField);

--- a/reg-lib/cpu/_reg_localTrans.cpp
+++ b/reg-lib/cpu/_reg_localTrans.cpp
@@ -2242,6 +2242,12 @@ void reg_defField_compose2D(const nifti_image *deformationField,
                             nifti_image *dfToUpdate,
                             const int *mask,
                             const nifti_image *positionField = nullptr) {
+    if (positionField && (positionField->datatype != dfToUpdate->datatype ||
+                          positionField->nx != dfToUpdate->nx ||
+                          positionField->ny != dfToUpdate->ny ||
+                          positionField->nz != dfToUpdate->nz ||
+                          positionField->nu != dfToUpdate->nu))
+        NR_FATAL_ERROR("The position field must share the deformation field's geometry and data type");
     const size_t dfVoxelNumber = NiftiImage::calcVoxelNumber(deformationField, 2);
 #ifdef _WIN32
     long i;
@@ -2341,6 +2347,12 @@ void reg_defField_compose3D(const nifti_image *deformationField,
                             nifti_image *dfToUpdate,
                             const int *mask,
                             const nifti_image *positionField = nullptr) {
+    if (positionField && (positionField->datatype != dfToUpdate->datatype ||
+                          positionField->nx != dfToUpdate->nx ||
+                          positionField->ny != dfToUpdate->ny ||
+                          positionField->nz != dfToUpdate->nz ||
+                          positionField->nu != dfToUpdate->nu))
+        NR_FATAL_ERROR("The position field must share the deformation field's geometry and data type");
     const size_t dfVoxelNumber = NiftiImage::calcVoxelNumber(deformationField, 3);
 #ifdef _WIN32
     long i;

--- a/reg-lib/cpu/_reg_localTrans.cpp
+++ b/reg-lib/cpu/_reg_localTrans.cpp
@@ -2480,6 +2480,13 @@ void reg_defField_compose(const nifti_image *deformationField,
     if (deformationField->datatype != dfToUpdate->datatype)
         NR_FATAL_ERROR("Both deformation fields are expected to have the same type");
 
+    if (positionField && (positionField->datatype != dfToUpdate->datatype ||
+                        positionField->nx != dfToUpdate->nx ||
+                        positionField->ny != dfToUpdate->ny ||
+                        positionField->nz != dfToUpdate->nz ||
+                        positionField->nu != dfToUpdate->nu))
+        NR_FATAL_ERROR("The position field must share the deformation field's geometry and data type");
+
     unique_ptr<int[]> currentMask;
     if (!mask) {
         currentMask.reset(new int[NiftiImage::calcVoxelNumber(dfToUpdate, 3)]());

--- a/reg-lib/cpu/_reg_localTrans.h
+++ b/reg-lib/cpu/_reg_localTrans.h
@@ -133,10 +133,16 @@ int reg_spline_cppComposition(nifti_image *grid1,
  * @param mask Mask overlaid on the dfToUpdate field where only voxel
  * within the mask will be updated. All positive values in the mask
  * are considered as belonging to the mask.
+ * @param positionField Optional field supplying the lookup positions. When null (default) the
+ * positions are read from dfToUpdate (in-place composition). When provided, the positions are
+ * read from it and the result written to dfToUpdate, so the source and destination fields never
+ * alias - used by the scaling-and-squaring loop to ping-pong between two buffers instead of
+ * copying the field back after every step. positionField must share dfToUpdate's geometry.
  */
 void reg_defField_compose(const nifti_image *deformationField,
                           nifti_image *dfToUpdate,
-                          const int *mask);
+                          const int *mask,
+                          const nifti_image *positionField = nullptr);
 /* *************************************************************** */
 /** @brief Compute the inverse of a deformation field
  * @author Marcel van Herk (CMIC / NKI / AVL)

--- a/reg-lib/cpu/_reg_tools.cpp
+++ b/reg-lib/cpu/_reg_tools.cpp
@@ -828,13 +828,51 @@ void reg_tools_divideValueToImage(const nifti_image *img,
     }
 }
 /* *************************************************************** */
-template <class DataType>
+/* Fill the separable convolution weights for one axis and return their sum. Shared by the single-
+ * and multi-image CPU convolution cores (identical maths). The Mean weights are only used in 2D
+ * (@p is2d); the 3D Mean uses the cumulative kernelSum == 0 path and leaves the array untouched. */
+static double FillConvolutionKernel(float *kernel, const int radius, const double temp,
+                                    const ConvKernelType kernelType, const bool is2d) {
+    double kernelSum = 0;
+    if (kernelType == ConvKernelType::Cubic) {
+        // Cubic Spline kernel (temp contains the kernel node spacing)
+        for (int i = -radius; i <= radius; i++) {
+            double relative = fabs(i / temp);
+            if (relative < 1.0)
+                kernel[i + radius] = static_cast<float>(2.0 / 3.0 - Square(relative) + 0.5 * Cube(relative));
+            else if (relative < 2.0)
+                kernel[i + radius] = static_cast<float>(-Cube(relative - 2.0) / 6.0);
+            else kernel[i + radius] = 0;
+            kernelSum += kernel[i + radius];
+        }
+    } else if (kernelType == ConvKernelType::Gaussian) {
+        // Gaussian kernel; 2.506... = sqrt(2*pi), temp contains the sigma in voxel
+        for (int i = -radius; i <= radius; i++) {
+            kernel[radius + i] = static_cast<float>(exp(-Square(i) / (2.0 * Square(temp))) / (temp * 2.506628274631));
+            kernelSum += kernel[radius + i];
+        }
+    } else if (kernelType == ConvKernelType::Linear) {
+        for (int i = -radius; i <= radius; i++) {
+            kernel[radius + i] = 1.f - fabs(i / static_cast<float>(radius));
+            kernelSum += kernel[radius + i];
+        }
+    } else if (kernelType == ConvKernelType::Mean && is2d) {
+        for (int i = -radius; i <= radius; i++) {
+            kernel[radius + i] = 1.f;
+            kernelSum += kernel[radius + i];
+        }
+    }
+    return kernelSum;
+}
+/* *************************************************************** */
+template <class DataType, class AccType>
 void reg_tools_kernelConvolution(nifti_image *image,
                                  const float *sigma,
                                  const ConvKernelType kernelType,
                                  const int *mask,
                                  const bool *timePoints,
-                                 const bool *axes) {
+                                 const bool *axes,
+                                 ConvolutionWorkspace *workspace) {
     if (image->nx > 2048 || image->ny > 2048 || image->nz > 2048)
         NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
 
@@ -849,8 +887,24 @@ void reg_tools_kernelConvolution(nifti_image *image,
     DataType *imagePtr = static_cast<DataType*>(image->data);
     const int imageDims[3]{ image->nx, image->ny, image->nz };
 
-    unique_ptr<bool[]> nanImagePtr{ new bool[voxelNumber]() };
-    unique_ptr<float[]> densityPtr{ new float[voxelNumber]() };
+    unique_ptr<bool[]> localNanImage;
+    unique_ptr<float[]> localDensity;
+    bool *nanImagePtr;
+    float *densityPtr;
+    bool computeDensity = true;
+    if (workspace) {
+        workspace->EnsureSize(voxelNumber);
+        nanImagePtr = workspace->nanImage.get();
+        densityPtr = workspace->density.get();
+#ifndef USE_SSE
+        computeDensity = !workspace->densityValid;
+#endif
+    } else {
+        localNanImage.reset(new bool[voxelNumber]());
+        localDensity.reset(new float[voxelNumber]());
+        nanImagePtr = localNanImage.get();
+        densityPtr = localDensity.get();
+    }
 
     // Loop over the dimension higher than 3
     for (int t = 0; t < image->nt * image->nu; t++) {
@@ -858,11 +912,15 @@ void reg_tools_kernelConvolution(nifti_image *image,
             DataType *intensityPtr = &imagePtr[t * voxelNumber];
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-   shared(densityPtr, intensityPtr, mask, nanImagePtr, voxelNumber)
+   shared(densityPtr, intensityPtr, mask, nanImagePtr, voxelNumber, computeDensity)
 #endif
             for (index = 0; index < voxelNumber; index++) {
-                densityPtr[index] = mask[index] >= 0 && intensityPtr[index] == intensityPtr[index] ? 1.f : 0;
-                nanImagePtr[index] = !static_cast<bool>(densityPtr[index]);
+                if (computeDensity) {
+                    densityPtr[index] = mask[index] >= 0 && intensityPtr[index] == intensityPtr[index] ? 1.f : 0;
+                    nanImagePtr[index] = !static_cast<bool>(densityPtr[index]);
+                }
+                // Zero this image's out-of-density voxels so they do not leak NaN into the
+                // convolution (in reuse mode the cached nanImage marks the same voxels)
                 if (nanImagePtr[index]) intensityPtr[index] = 0;
             }
             // Loop over the x, y and z dimensions
@@ -886,45 +944,10 @@ void reg_tools_kernelConvolution(nifti_image *image,
                         NR_FATAL_ERROR("Unknown kernel type");
                     }
                     if (radius > 0) {
-                        // Allocate the kernel
+                        // Allocate and fill the kernel (shared with the multi-image core). No kernel
+                        // normalisation is needed as this is handled by the density function.
                         float kernel[4096];
-                        double kernelSum = 0;
-                        // Fill the kernel
-                        if (kernelType == ConvKernelType::Cubic) {
-                            // Compute the Cubic Spline kernel
-                            for (int i = -radius; i <= radius; i++) {
-                                // temp contains the kernel node spacing
-                                double relative = fabs(i / temp);
-                                if (relative < 1.0)
-                                    kernel[i + radius] = static_cast<float>(2.0 / 3.0 - Square(relative) + 0.5 * Cube(relative));
-                                else if (relative < 2.0)
-                                    kernel[i + radius] = static_cast<float>(-Cube(relative - 2.0) / 6.0);
-                                else kernel[i + radius] = 0;
-                                kernelSum += kernel[i + radius];
-                            }
-                        } else if (kernelType == ConvKernelType::Gaussian) {
-                            // Compute the Gaussian kernel
-                            for (int i = -radius; i <= radius; i++) {
-                                // 2.506... = sqrt(2*pi)
-                                // temp contains the sigma in voxel
-                                kernel[radius + i] = static_cast<float>(exp(-Square(i) / (2.0 * Square(temp))) / (temp * 2.506628274631));
-                                kernelSum += kernel[radius + i];
-                            }
-                        } else if (kernelType == ConvKernelType::Linear) {
-                            // Compute the linear kernel
-                            for (int i = -radius; i <= radius; i++) {
-                                kernel[radius + i] = 1.f - fabs(i / static_cast<float>(radius));
-                                kernelSum += kernel[radius + i];
-                            }
-                        } else if (kernelType == ConvKernelType::Mean && imageDims[2] == 1) {
-                            // Compute the mean kernel
-                            for (int i = -radius; i <= radius; i++) {
-                                kernel[radius + i] = 1.f;
-                                kernelSum += kernel[radius + i];
-                            }
-                        }
-                        // No kernel is required for the mean filtering
-                        // No need for kernel normalisation as this is handled by the density function
+                        const double kernelSum = FillConvolutionKernel(kernel, radius, temp, kernelType, imageDims[2] == 1);
                         NR_DEBUG("Convolution type[" << int(kernelType) << "] dim[" << n << "] tp[" << t << "] radius[" << radius << "] kernelSum[" << kernelSum << "]");
 
                         int planeNumber, planeIndex, lineOffset;
@@ -946,13 +969,14 @@ void reg_tools_kernelConvolution(nifti_image *image,
 
                         size_t realIndex;
                         float *kernelPtr, kernelValue;
-                        double densitySum, intensitySum;
+                        // AccType (double by default, float for LNCC) sets the accumulation precision
+                        AccType densitySum, intensitySum;
                         DataType *currentIntensityPtr = nullptr;
                         float *currentDensityPtr = nullptr;
                         DataType bufferIntensity[2048];
                         float bufferDensity[2048];
-                        double bufferIntensityCur = 0;
-                        double bufferDensityCur = 0;
+                        AccType bufferIntensityCur = 0;
+                        AccType bufferDensityCur = 0;
 
 #ifdef USE_SSE
                         union {
@@ -965,14 +989,14 @@ void reg_tools_kernelConvolution(nifti_image *image,
 #ifdef _OPENMP
 #ifdef USE_SSE
 #pragma omp parallel for default(none) \
-   shared(imageDims, intensityPtr, densityPtr, radius, kernel, lineOffset, n, planeNumber, kernelSum) \
+   shared(imageDims, intensityPtr, densityPtr, radius, kernel, lineOffset, n, planeNumber, kernelSum, computeDensity) \
    private(realIndex, currentIntensityPtr, currentDensityPtr, lineIndex, bufferIntensity, \
    bufferDensity, shiftPre, shiftPst, kernelPtr, kernelValue, densitySum, intensitySum, \
    k, bufferIntensityCur, bufferDensityCur, \
    kernel_sse, intensity_sse, density_sse, intensity_sum_sse, density_sum_sse)
 #else
 #pragma omp parallel for default(none) \
-   shared(imageDims, intensityPtr, densityPtr, radius, kernel, lineOffset, n, planeNumber, kernelSum) \
+   shared(imageDims, intensityPtr, densityPtr, radius, kernel, lineOffset, n, planeNumber, kernelSum, computeDensity) \
    private(realIndex, currentIntensityPtr, currentDensityPtr, lineIndex, bufferIntensity, \
    bufferDensity, shiftPre, shiftPst, kernelPtr, kernelValue, densitySum, intensitySum, \
    k, bufferIntensityCur, bufferDensityCur)
@@ -998,7 +1022,7 @@ void reg_tools_kernelConvolution(nifti_image *image,
                             currentDensityPtr = &densityPtr[realIndex];
                             for (lineIndex = 0; lineIndex < imageDims[n]; ++lineIndex) {
                                 bufferIntensity[lineIndex] = *currentIntensityPtr;
-                                bufferDensity[lineIndex] = *currentDensityPtr;
+                                if (computeDensity) bufferDensity[lineIndex] = *currentDensityPtr;
                                 currentIntensityPtr += lineOffset;
                                 currentDensityPtr += lineOffset;
                             }
@@ -1054,19 +1078,19 @@ void reg_tools_kernelConvolution(nifti_image *image,
                                     for (k = shiftPre; k < shiftPst; ++k) {
                                         kernelValue = *kernelPtr++;
                                         intensitySum += kernelValue * bufferIntensity[k];
-                                        densitySum += kernelValue * bufferDensity[k];
+                                        if (computeDensity) densitySum += kernelValue * bufferDensity[k];
                                     }
 #endif
                                     // Store the computed value inplace
                                     intensityPtr[realIndex] = static_cast<DataType>(intensitySum);
-                                    densityPtr[realIndex] = static_cast<float>(densitySum);
+                                    if (computeDensity) densityPtr[realIndex] = static_cast<float>(densitySum);
                                     realIndex += lineOffset;
                                 } // line convolution
                             } // kernel sum
                             else {
                                 for (lineIndex = 1; lineIndex < imageDims[n]; ++lineIndex) {
                                     bufferIntensity[lineIndex] += bufferIntensity[lineIndex - 1];
-                                    bufferDensity[lineIndex] += bufferDensity[lineIndex - 1];
+                                    if (computeDensity) bufferDensity[lineIndex] += bufferDensity[lineIndex - 1];
                                 }
                                 shiftPre = -radius - 1;
                                 shiftPst = radius;
@@ -1074,22 +1098,22 @@ void reg_tools_kernelConvolution(nifti_image *image,
                                     if (shiftPre > -1) {
                                         if (shiftPst < imageDims[n]) {
                                             bufferIntensityCur = bufferIntensity[shiftPre] - bufferIntensity[shiftPst];
-                                            bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[shiftPst];
+                                            if (computeDensity) bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[shiftPst];
                                         } else {
                                             bufferIntensityCur = bufferIntensity[shiftPre] - bufferIntensity[imageDims[n] - 1];
-                                            bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[imageDims[n] - 1];
+                                            if (computeDensity) bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[imageDims[n] - 1];
                                         }
                                     } else {
                                         if (shiftPst < imageDims[n]) {
                                             bufferIntensityCur = -bufferIntensity[shiftPst];
-                                            bufferDensityCur = -bufferDensity[shiftPst];
+                                            if (computeDensity) bufferDensityCur = -bufferDensity[shiftPst];
                                         } else {
                                             bufferIntensityCur = 0;
                                             bufferDensityCur = 0;
                                         }
                                     }
                                     intensityPtr[realIndex] = static_cast<DataType>(bufferIntensityCur);
-                                    densityPtr[realIndex] = static_cast<float>(bufferDensityCur);
+                                    if (computeDensity) densityPtr[realIndex] = static_cast<float>(bufferDensityCur);
                                     realIndex += lineOffset;
                                 } // line convolution of mean filter
                             } // No kernel computation
@@ -1109,6 +1133,293 @@ void reg_tools_kernelConvolution(nifti_image *image,
             }
         } // check if the time point is active
     } // loop over the time points
+
+    // The workspace now holds the smoothed density and NaN mask for this call's mask; a subsequent
+    // convolution sharing the same density can reuse them (the caller resets densityValid when the
+    // mask/density changes).
+    if (workspace)
+        workspace->densityValid = true;
+}
+/* *************************************************************** */
+/* Templated core of reg_tools_kernelConvolutionMulti (see the header for the contract). NImages
+ * independent per-image accumulators sit contiguously in an interleaved line buffer so the compiler
+ * can vectorise across images without reordering any single image's sum (hence bit-for-bit identical
+ * to convolving each image alone). Scalar path only. */
+template <class DataType, class AccType, int NImages>
+void reg_tools_kernelConvolutionMulti(nifti_image *const *images,
+                                      const float *sigma,
+                                      const ConvKernelType kernelType,
+                                      const int *mask,
+                                      ConvolutionWorkspace *workspace) {
+    if (images[0]->nx > 2048 || images[0]->ny > 2048 || images[0]->nz > 2048)
+        NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
+
+#ifdef WIN32
+    long index;
+    const long voxelNumber = (long)NiftiImage::calcVoxelNumber(images[0], 3);
+#else
+    size_t index;
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(images[0], 3);
+#endif
+
+    DataType *imagePtrs[NImages];
+    for (int c = 0; c < NImages; ++c) imagePtrs[c] = static_cast<DataType*>(images[c]->data);
+    const int imageDims[3]{ images[0]->nx, images[0]->ny, images[0]->nz };
+
+    // Scratch handling mirrors the single-image core (see above): the density is computed once
+    // (from images[0], identical across images by the shared-NaN-pattern requirement) or reused
+    // when the workspace holds a valid one.
+    unique_ptr<bool[]> localNanImage;
+    unique_ptr<float[]> localDensity;
+    bool *nanImagePtr;
+    float *densityPtr;
+    bool computeDensity = true;
+    if (workspace) {
+        workspace->EnsureSize(voxelNumber);
+        nanImagePtr = workspace->nanImage.get();
+        densityPtr = workspace->density.get();
+        computeDensity = !workspace->densityValid;
+    } else {
+        localNanImage.reset(new bool[voxelNumber]());
+        localDensity.reset(new float[voxelNumber]());
+        nanImagePtr = localNanImage.get();
+        densityPtr = localDensity.get();
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+   shared(densityPtr, imagePtrs, mask, nanImagePtr, voxelNumber, computeDensity)
+#endif
+    for (index = 0; index < voxelNumber; index++) {
+        if (computeDensity) {
+            const DataType value = imagePtrs[0][index];
+            densityPtr[index] = mask[index] >= 0 && value == value ? 1.f : 0;
+            nanImagePtr[index] = !static_cast<bool>(densityPtr[index]);
+        }
+        // Zero the out-of-density voxels of every image (shared NaN pattern) so they do not leak
+        // NaN into the convolution
+        if (nanImagePtr[index])
+            for (int c = 0; c < NImages; ++c) imagePtrs[c][index] = 0;
+    }
+    // Loop over the x, y and z dimensions
+    for (int n = 0; n < 3; n++) {
+        if (images[0]->dim[n] > 1) {
+            double temp;
+            if (sigma[0] > 0) temp = sigma[0] / images[0]->pixdim[n + 1]; // mm to voxel
+            else temp = fabs(sigma[0]); // voxel-based if negative value
+            int radius = 0;
+            // Define the kernel size
+            if (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear) {
+                // Mean or linear filtering
+                radius = static_cast<int>(temp);
+            } else if (kernelType == ConvKernelType::Gaussian) {
+                // Gaussian kernel
+                radius = static_cast<int>(temp * 3.0f);
+            } else if (kernelType == ConvKernelType::Cubic) {
+                // Spline kernel
+                radius = static_cast<int>(temp * 2.0f);
+            } else {
+                NR_FATAL_ERROR("Unknown kernel type");
+            }
+            if (radius > 0) {
+                // Allocate and fill the kernel (shared with the single-image core)
+                float kernel[4096];
+                const double kernelSum = FillConvolutionKernel(kernel, radius, temp, kernelType, imageDims[2] == 1);
+                NR_DEBUG("Multi convolution type[" << int(kernelType) << "] dim[" << n << "] radius[" << radius << "] kernelSum[" << kernelSum << "]");
+
+                int planeNumber, planeIndex, lineOffset;
+                int lineIndex, shiftPre, shiftPst, k;
+                switch (n) {
+                case 0:
+                    planeNumber = imageDims[1] * imageDims[2];
+                    lineOffset = 1;
+                    break;
+                case 1:
+                    planeNumber = imageDims[0] * imageDims[2];
+                    lineOffset = imageDims[0];
+                    break;
+                case 2:
+                    planeNumber = imageDims[0] * imageDims[1];
+                    lineOffset = planeNumber;
+                    break;
+                }
+
+                size_t realIndex;
+                float *kernelPtr, kernelValue;
+                AccType densitySum, intensitySums[NImages];
+                float *currentDensityPtr = nullptr;
+                // Interleaved line buffer: element [lineIndex * NImages + c] holds image c, so the
+                // NImages accumulator updates of one tap read contiguous memory (vectorisable)
+                DataType bufferIntensity[2048 * NImages];
+                float bufferDensity[2048];
+                AccType bufferIntensityCur[NImages];
+                AccType bufferDensityCur = 0;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+   shared(imageDims, imagePtrs, densityPtr, radius, kernel, lineOffset, n, planeNumber, kernelSum, computeDensity) \
+   private(realIndex, currentDensityPtr, lineIndex, bufferIntensity, \
+   bufferDensity, shiftPre, shiftPst, kernelPtr, kernelValue, densitySum, intensitySums, \
+   k, bufferIntensityCur, bufferDensityCur)
+#endif // _OPENMP
+                for (planeIndex = 0; planeIndex < planeNumber; ++planeIndex) {
+                    switch (n) {
+                    case 0:
+                        realIndex = planeIndex * imageDims[0];
+                        break;
+                    case 1:
+                        realIndex = (planeIndex / imageDims[0]) * imageDims[0] * imageDims[1] + planeIndex % imageDims[0];
+                        break;
+                    case 2:
+                        realIndex = planeIndex;
+                        break;
+                    default:
+                        realIndex = 0;
+                    }
+                    // Fetch the current line of every image into the interleaved stack buffer
+                    currentDensityPtr = &densityPtr[realIndex];
+                    for (lineIndex = 0; lineIndex < imageDims[n]; ++lineIndex) {
+                        const size_t fetchIndex = realIndex + static_cast<size_t>(lineIndex) * lineOffset;
+                        for (int c = 0; c < NImages; ++c)
+                            bufferIntensity[lineIndex * NImages + c] = imagePtrs[c][fetchIndex];
+                        if (computeDensity) bufferDensity[lineIndex] = *currentDensityPtr;
+                        currentDensityPtr += lineOffset;
+                    }
+                    if (kernelSum > 0) {
+                        // Perform the kernel convolution along one line
+                        for (lineIndex = 0; lineIndex < imageDims[n]; ++lineIndex) {
+                            // Define the kernel boundaries
+                            shiftPre = lineIndex - radius;
+                            shiftPst = lineIndex + radius + 1;
+                            if (shiftPre < 0) {
+                                kernelPtr = &kernel[-shiftPre];
+                                shiftPre = 0;
+                            } else kernelPtr = &kernel[0];
+                            if (shiftPst > imageDims[n]) shiftPst = imageDims[n];
+                            // NImages independent accumulations per tap, each in the same order as
+                            // the single-image core - hence bit-exact per image
+                            for (int c = 0; c < NImages; ++c) intensitySums[c] = 0;
+                            densitySum = 0;
+                            for (k = shiftPre; k < shiftPst; ++k) {
+                                kernelValue = *kernelPtr++;
+                                const DataType *bufferTap = &bufferIntensity[k * NImages];
+                                for (int c = 0; c < NImages; ++c)
+                                    intensitySums[c] += kernelValue * bufferTap[c];
+                                if (computeDensity) densitySum += kernelValue * bufferDensity[k];
+                            }
+                            // Store the computed values inplace
+                            for (int c = 0; c < NImages; ++c)
+                                imagePtrs[c][realIndex] = static_cast<DataType>(intensitySums[c]);
+                            if (computeDensity) densityPtr[realIndex] = static_cast<float>(densitySum);
+                            realIndex += lineOffset;
+                        } // line convolution
+                    } // kernel sum
+                    else {
+                        // Cumulative (running-sum) mean filter
+                        for (lineIndex = 1; lineIndex < imageDims[n]; ++lineIndex) {
+                            for (int c = 0; c < NImages; ++c)
+                                bufferIntensity[lineIndex * NImages + c] += bufferIntensity[(lineIndex - 1) * NImages + c];
+                            if (computeDensity) bufferDensity[lineIndex] += bufferDensity[lineIndex - 1];
+                        }
+                        shiftPre = -radius - 1;
+                        shiftPst = radius;
+                        for (lineIndex = 0; lineIndex < imageDims[n]; ++lineIndex, ++shiftPre, ++shiftPst) {
+                            if (shiftPre > -1) {
+                                if (shiftPst < imageDims[n]) {
+                                    for (int c = 0; c < NImages; ++c)
+                                        bufferIntensityCur[c] = bufferIntensity[shiftPre * NImages + c] - bufferIntensity[shiftPst * NImages + c];
+                                    if (computeDensity) bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[shiftPst];
+                                } else {
+                                    for (int c = 0; c < NImages; ++c)
+                                        bufferIntensityCur[c] = bufferIntensity[shiftPre * NImages + c] - bufferIntensity[(imageDims[n] - 1) * NImages + c];
+                                    if (computeDensity) bufferDensityCur = bufferDensity[shiftPre] - bufferDensity[imageDims[n] - 1];
+                                }
+                            } else {
+                                if (shiftPst < imageDims[n]) {
+                                    for (int c = 0; c < NImages; ++c)
+                                        bufferIntensityCur[c] = -bufferIntensity[shiftPst * NImages + c];
+                                    if (computeDensity) bufferDensityCur = -bufferDensity[shiftPst];
+                                } else {
+                                    for (int c = 0; c < NImages; ++c)
+                                        bufferIntensityCur[c] = 0;
+                                    bufferDensityCur = 0;
+                                }
+                            }
+                            for (int c = 0; c < NImages; ++c)
+                                imagePtrs[c][realIndex] = static_cast<DataType>(bufferIntensityCur[c]);
+                            if (computeDensity) densityPtr[realIndex] = static_cast<float>(bufferDensityCur);
+                            realIndex += lineOffset;
+                        } // line convolution of mean filter
+                    } // No kernel computation
+                } // pixel in starting plane
+            } // radius > 0
+        } // active axis
+    } // axes
+    // Normalise
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+   shared(voxelNumber, imagePtrs, densityPtr, nanImagePtr)
+#endif
+    for (index = 0; index < voxelNumber; ++index) {
+        if (nanImagePtr[index])
+            for (int c = 0; c < NImages; ++c)
+                imagePtrs[c][index] = std::numeric_limits<DataType>::quiet_NaN();
+        else
+            for (int c = 0; c < NImages; ++c)
+                imagePtrs[c][index] = static_cast<DataType>(imagePtrs[c][index] / densityPtr[index]);
+    }
+
+    if (workspace)
+        workspace->densityValid = true;
+}
+/* *************************************************************** */
+void reg_tools_kernelConvolutionMulti(nifti_image *const *images,
+                                      const int imageCount,
+                                      const float *sigma,
+                                      const ConvKernelType kernelType,
+                                      const int *mask,
+                                      ConvolutionWorkspace *workspace) {
+    if (imageCount < 1 || imageCount > 4)
+        NR_FATAL_ERROR("Between one and four images are expected");
+    for (int c = 0; c < imageCount; ++c) {
+        if (images[c]->datatype != NIFTI_TYPE_FLOAT32 && images[c]->datatype != NIFTI_TYPE_FLOAT64)
+            NR_FATAL_ERROR("The images are expected to be of floating precision type");
+        if (images[c]->datatype != images[0]->datatype || images[c]->nvox != images[0]->nvox)
+            NR_FATAL_ERROR("The images are expected to share their data type and size");
+        if (images[c]->nt * images[c]->nu > 1)
+            NR_FATAL_ERROR("Only single-time-point images are supported");
+    }
+
+    if (imageCount == 1)
+        return reg_tools_kernelConvolution(images[0], sigma, kernelType, mask, nullptr, nullptr, workspace);
+
+#ifdef USE_SSE
+    // The SSE convolution path is kept byte-for-byte unchanged, so the multi-image sweep (a scalar
+    // optimisation) is not used there: fall back to sequential single-image convolutions.
+    for (int c = 0; c < imageCount; ++c)
+        reg_tools_kernelConvolution(images[c], sigma, kernelType, mask, nullptr, nullptr, workspace);
+#else
+    unique_ptr<int[]> currentMask;
+    if (!mask) {
+        currentMask.reset(new int[NiftiImage::calcVoxelNumber(images[0], 3)]());
+        mask = currentMask.get();
+    }
+
+    const bool useFloat = workspace && workspace->useFloatAccumulation;
+    std::visit([&](auto&& imgDataType) {
+        using ImgDataType = std::decay_t<decltype(imgDataType)>;
+        auto convolve = [&](auto accType) {
+            using AccType = std::decay_t<decltype(accType)>;
+            switch (imageCount) {
+            case 2: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 2>(images, sigma, kernelType, mask, workspace); break;
+            case 3: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 3>(images, sigma, kernelType, mask, workspace); break;
+            case 4: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 4>(images, sigma, kernelType, mask, workspace); break;
+            }
+        };
+        if (useFloat) convolve(float{});
+        else convolve(double{});
+    }, NiftiImage::getFloatingDataType(images[0]));
+#endif
 }
 /* *************************************************************** */
 template <class DataType>
@@ -1308,7 +1619,8 @@ void reg_tools_kernelConvolution(nifti_image *image,
                                  const ConvKernelType kernelType,
                                  const int *mask,
                                  const bool *timePoints,
-                                 const bool *axes) {
+                                 const bool *axes,
+                                 ConvolutionWorkspace *workspace) {
     if (image->datatype != NIFTI_TYPE_FLOAT32 && image->datatype != NIFTI_TYPE_FLOAT64)
         NR_FATAL_ERROR("The image is expected to be of floating precision type");
 
@@ -1334,9 +1646,13 @@ void reg_tools_kernelConvolution(nifti_image *image,
         mask = currentMask.get();
     }
 
+    const bool useFloat = workspace && workspace->useFloatAccumulation;
     std::visit([&](auto&& imgDataType) {
         using ImgDataType = std::decay_t<decltype(imgDataType)>;
-        reg_tools_kernelConvolution<ImgDataType>(image, sigma, kernelType, mask, activeTimePoints.get(), axesToSmooth);
+        if (useFloat)
+            reg_tools_kernelConvolution<ImgDataType, float>(image, sigma, kernelType, mask, activeTimePoints.get(), axesToSmooth, workspace);
+        else
+            reg_tools_kernelConvolution<ImgDataType, double>(image, sigma, kernelType, mask, activeTimePoints.get(), axesToSmooth, workspace);
     }, NiftiImage::getFloatingDataType(image));
 }
 /* *************************************************************** */

--- a/reg-lib/cpu/_reg_tools.cpp
+++ b/reg-lib/cpu/_reg_tools.cpp
@@ -1151,8 +1151,12 @@ void reg_tools_kernelConvolutionMulti(nifti_image *const *images,
                                       const ConvKernelType kernelType,
                                       const int *mask,
                                       ConvolutionWorkspace *workspace) {
-    if (images[0]->nx > 2048 || images[0]->ny > 2048 || images[0]->nz > 2048)
-        NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
+    for (int c = 0; c < NImages; ++c) {
+        if (images[c]->nx > 2048 || images[c]->ny > 2048 || images[c]->nz > 2048)
+            NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
+        if (images[c]->nx != images[0]->nx || images[c]->ny != images[0]->ny || images[c]->nz != images[0]->nz)
+            NR_FATAL_ERROR("All images are expected to share the same dimensions");
+    }
 
 #ifdef WIN32
     long index;

--- a/reg-lib/cpu/_reg_tools.cpp
+++ b/reg-lib/cpu/_reg_tools.cpp
@@ -1408,16 +1408,19 @@ void reg_tools_kernelConvolutionMulti(nifti_image *const *images,
     const bool useFloat = workspace && workspace->useFloatAccumulation;
     std::visit([&](auto&& imgDataType) {
         using ImgDataType = std::decay_t<decltype(imgDataType)>;
-        auto convolve = [&](auto accType) {
-            using AccType = std::decay_t<decltype(accType)>;
+        auto call = [&]<class AccType, int N>(AccType, std::integral_constant<int, N>) {
+            reg_tools_kernelConvolutionMulti<ImgDataType, AccType, N>(images, sigma, kernelType, mask, workspace);
+        };
+        auto dispatchCount = [&](auto acc) {
             switch (imageCount) {
-            case 2: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 2>(images, sigma, kernelType, mask, workspace); break;
-            case 3: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 3>(images, sigma, kernelType, mask, workspace); break;
-            case 4: reg_tools_kernelConvolutionMulti<ImgDataType, AccType, 4>(images, sigma, kernelType, mask, workspace); break;
+            case 2: call(acc, std::integral_constant<int, 2>{}); break;
+            case 3: call(acc, std::integral_constant<int, 3>{}); break;
+            case 4: call(acc, std::integral_constant<int, 4>{}); break;
+            default: throw std::runtime_error("unsupported image count");
             }
         };
-        if (useFloat) convolve(float{});
-        else convolve(double{});
+        if (useFloat) dispatchCount(float{});
+        else          dispatchCount(double{});
     }, NiftiImage::getFloatingDataType(images[0]));
 #endif
 }

--- a/reg-lib/cpu/_reg_tools.h
+++ b/reg-lib/cpu/_reg_tools.h
@@ -76,6 +76,31 @@ void reg_tools_removeSCLInfo(nifti_image *img);
 void reg_getRealImageSpacing(nifti_image *image,
                              float *spacingValues);
 /* *************************************************************** */
+/** @brief Reusable scratch for reg_tools_kernelConvolution.
+ *
+ * Passing the same workspace to repeated convolutions avoids re-allocating (and zero-initialising)
+ * the per-call density and NaN-mask buffers. It can also cache the smoothed density field: when
+ * @c densityValid is true the next convolution reuses the cached density instead of recomputing it,
+ * which lets a routine that convolves several images sharing one mask (e.g. LNCC's five
+ * convolutions) compute the density only once. The caller must keep @c densityValid true only
+ * across convolutions that genuinely share the same density - same mask, every in-mask voxel finite
+ * in every image (the LNCC scratch images qualify).
+ */
+struct ConvolutionWorkspace {
+    std::unique_ptr<float[]> density;
+    std::unique_ptr<bool[]> nanImage;
+    size_t size = 0;
+    bool densityValid = false;
+    // Accumulate the weighted sum in float instead of double.
+    bool useFloatAccumulation = false;
+    void EnsureSize(const size_t voxelNumber) {
+        if (size >= voxelNumber) return;
+        density.reset(new float[voxelNumber]);
+        nanImage.reset(new bool[voxelNumber]);
+        size = voxelNumber;
+    }
+};
+/* *************************************************************** */
 /** @brief Smooth an image using a specified kernel
  * @param image Image to be smoothed
  * @param sigma Standard deviation of the kernel to use.
@@ -86,13 +111,35 @@ void reg_getRealImageSpacing(nifti_image *image,
  * smoothed. The array follow the dim array of the nifti header.
  * @param axes Boolean array to specify which axes have to be
  * smoothed. The array follow the dim array of the nifti header.
+ * @param workspace Optional reusable scratch (see ConvolutionWorkspace). When nullptr (default) the
+ * buffers are allocated locally and the density is always recomputed, i.e. unchanged behaviour.
  */
 void reg_tools_kernelConvolution(nifti_image *image,
                                  const float *sigma,
                                  const ConvKernelType kernelType,
                                  const int *mask = nullptr,
                                  const bool *timePoints = nullptr,
-                                 const bool *axes = nullptr);
+                                 const bool *axes = nullptr,
+                                 ConvolutionWorkspace *workspace = nullptr);
+/* *************************************************************** */
+/** @brief Smooth up to four single-time-point images sharing the same geometry, mask and kernel in
+ * a single sweep. Per image the result is bit-for-bit identical to calling
+ * reg_tools_kernelConvolution on it alone, but the line fetches, kernel weights and density
+ * computation are shared, and the per-tap accumulators are laid out so the compiler can vectorise
+ * across images without reordering any single image's sum.
+ * @param images Array of imageCount images to be smoothed (all axes, first time point)
+ * @param imageCount Number of images (1 to 4)
+ * @param sigma Standard deviation of the kernel (sigma[0] applies to every image)
+ * @param kernelType Type of kernel to use
+ * @param mask An integer mask over which the smoothing should occur (may be nullptr)
+ * @param workspace Optional reusable scratch (see ConvolutionWorkspace)
+ */
+void reg_tools_kernelConvolutionMulti(nifti_image *const *images,
+                                      const int imageCount,
+                                      const float *sigma,
+                                      const ConvKernelType kernelType,
+                                      const int *mask = nullptr,
+                                      ConvolutionWorkspace *workspace = nullptr);
 /* *************************************************************** */
 /** @brief Smooth a label image using a Gaussian kernel
  * @param image Image to be smoothed

--- a/reg-lib/cuda/CMakeLists.txt
+++ b/reg-lib/cuda/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(${NAME} ${NIFTYREG_LIBRARY_TYPE}
     CudaResampleImageKernel.cpp
     CudaResampling.cu
     CudaTools.cu
+    _reg_lncc_gpu.cu
     _reg_nmi_gpu.cu
     _reg_ssd_gpu.cu
 )

--- a/reg-lib/cuda/CudaCompute.cu
+++ b/reg-lib/cuda/CudaCompute.cu
@@ -215,45 +215,36 @@ void CudaCompute::GetApproximatedGradient(InterfaceOptimiser& opt) {
     Compute::GetApproximatedGradient(opt);
 }
 /* *************************************************************** */
+CudaCompute::CudaCompute(Content& con): Compute(con) {}
+CudaCompute::~CudaCompute() = default;
+/* *************************************************************** */
 void CudaCompute::GetDefFieldFromVelocityGrid(const bool updateStepNumber) {
     CudaF3dContent& con = dynamic_cast<CudaF3dContent&>(this->con);
+    if (!expWorkspace)
+        expWorkspace = std::make_unique<Cuda::ExponentiationWorkspace>();
     Cuda::GetDefFieldFromVelocityGrid(con.F3dContent::GetControlPointGrid(),
                                       con.F3dContent::GetDeformationField(),
                                       con.GetControlPointGridCuda(),
                                       con.GetDeformationFieldCuda(),
-                                      updateStepNumber);
+                                      updateStepNumber,
+                                      expWorkspace.get());
 }
 /* *************************************************************** */
 void CudaCompute::ConvolveImage(const NiftiImage& image, float4 *imageCuda) {
     const NiftiImage& controlPointGrid = dynamic_cast<F3dContent&>(con).F3dContent::GetControlPointGrid();
     constexpr ConvKernelType kernelType = ConvKernelType::Cubic;
-    float currentNodeSpacing[3];
-    currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dx;
-    bool activeAxis[3] = { 1, 0, 0 };
-    Cuda::KernelConvolution<kernelType>(image,
-                                        imageCuda,
-                                        currentNodeSpacing,
-                                        nullptr, // all volumes are considered as active
-                                        activeAxis);
-    // Convolution along the y axis
-    currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dy;
-    activeAxis[0] = 0;
-    activeAxis[1] = 1;
-    Cuda::KernelConvolution<kernelType>(image,
-                                        imageCuda,
-                                        currentNodeSpacing,
-                                        nullptr, // all volumes are considered as active
-                                        activeAxis);
-    // Convolution along the z axis if required
-    if (image->nz > 1) {
-        currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = controlPointGrid->dz;
-        activeAxis[1] = 0;
-        activeAxis[2] = 1;
-        Cuda::KernelConvolution<kernelType>(image,
-                                            imageCuda,
-                                            currentNodeSpacing,
-                                            nullptr, // all volumes are considered as active
-                                            activeAxis);
+    // Reuse the workspace so the per-axis passes pool their scratch
+    if (!convWorkspace)
+        convWorkspace = std::make_unique<Cuda::KernelConvolutionWorkspace>();
+    const float nodeSpacings[3]{ controlPointGrid->dx, controlPointGrid->dy, controlPointGrid->dz };
+    const int axisCount = image->nz > 1 ? 3 : 2;
+    for (int axis = 0; axis < axisCount; ++axis) {
+        float currentNodeSpacing[3];
+        currentNodeSpacing[0] = currentNodeSpacing[1] = currentNodeSpacing[2] = nodeSpacings[axis];
+        bool activeAxis[3]{ axis == 0, axis == 1, axis == 2 };
+        convWorkspace->densityValid = false; // recompute the density for this pass
+        Cuda::KernelConvolution<kernelType, float>(image, imageCuda, currentNodeSpacing,
+                                                   nullptr, activeAxis, nullptr, convWorkspace.get());
     }
 }
 /* *************************************************************** */
@@ -297,10 +288,15 @@ void CudaCompute::ExponentiateGradient(Content& conBwIn) {
     // Create all deformation field images needed for resampling
     const size_t defFieldNumber = deformationField.nVoxelsPerVolume();
     vector<NiftiImage> defFields(compNum + 1, NiftiImage(deformationField, NiftiImage::Copy::ImageInfo));
-    vector<thrust::device_vector<float4>> defFieldCudaVecs(compNum + 1, thrust::device_vector<float4>(defFieldNumber));
+
+    // Reuse the persistent workspace for the intermediate device fields (compNum + 1 buffers) so
+    // they are not reallocated every gradient step; the flow-field/mask scratch is reused too.
+    if (!expWorkspace)
+        expWorkspace = std::make_unique<Cuda::ExponentiationWorkspace>();
+    vector<thrust::device_vector<float4>>& defFieldCudaVecs = expWorkspace->GetIntermediates(compNum + 1, defFieldNumber);
 
     // Generate all intermediate deformation fields
-    Cuda::GetIntermediateDefFieldFromVelGrid(controlPointGridBw, controlPointGridBwCuda, defFields, defFieldCudaVecs);
+    Cuda::GetIntermediateDefFieldFromVelGrid(controlPointGridBw, controlPointGridBwCuda, defFields, defFieldCudaVecs, expWorkspace.get());
 
     // Remove the affine component
     NiftiImage affineDisp;

--- a/reg-lib/cuda/CudaCompute.h
+++ b/reg-lib/cuda/CudaCompute.h
@@ -3,9 +3,15 @@
 #include "Compute.h"
 #include "CudaCommon.hpp"
 
+namespace NiftyReg::Cuda { struct ExponentiationWorkspace; struct KernelConvolutionWorkspace; }
+
 class CudaCompute: public Compute {
 public:
-    CudaCompute(Content& con): Compute(con) {}
+    // Constructor and destructor are defined in the .cu so the incomplete ExponentiationWorkspace
+    // can be held by unique_ptr here without pulling thrust into this host-included header (the
+    // unique_ptr's destructor, needed by both, is only instantiated where the type is complete).
+    CudaCompute(Content& con);
+    ~CudaCompute();
 
     virtual void ResampleImage(int interpolation, float paddingValue) override;
     virtual double GetJacobianPenaltyTerm(bool approx) override;
@@ -42,4 +48,10 @@ protected:
 private:
     void ConvolveImage(const NiftiImage&, float4*);
     Cuda::UniquePtr<float4> ScaleGradient(const float4*, const size_t, const float);
+    // Reusable scratch for the velocity-field exponentiation, kept across iterations to avoid
+    // per-call cudaMalloc/cudaFree (lazily created on first -vel use).
+    std::unique_ptr<NiftyReg::Cuda::ExponentiationWorkspace> expWorkspace;
+    // Reusable scratch for the voxel-based-gradient smoothing convolutions (three per-axis passes
+    // per iteration), so their internal buffers are pooled rather than reallocated each pass.
+    std::unique_ptr<NiftyReg::Cuda::KernelConvolutionWorkspace> convWorkspace;
 };

--- a/reg-lib/cuda/CudaKernelConvolution.cu
+++ b/reg-lib/cuda/CudaKernelConvolution.cu
@@ -66,6 +66,36 @@ double ComputeKernelWeights(vector<float>& kernel, const int radius, const doubl
     return kernelSum;
 }
 /* *************************************************************** */
+// Kernel support radius (in voxels) for a per-axis spacing `temp`.
+template<ConvKernelType kernelType>
+int KernelRadius(const double temp) {
+    if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
+        return static_cast<int>(temp);
+    else if constexpr (kernelType == ConvKernelType::Gaussian)
+        return static_cast<int>(temp * 3.0);
+    else if constexpr (kernelType == ConvKernelType::Cubic)
+        return static_cast<int>(temp * 2.0);
+    else { NR_FATAL_ERROR("Unknown kernel type"); return 0; }
+}
+/* *************************************************************** */
+__device__ inline bool ConvVoxelActive(const float val) { return val == val; }
+__device__ inline bool ConvVoxelActive(const float4 val) { return val.x == val.x; }
+/* *************************************************************** */
+template<class T>
+__device__ inline void InitConvVoxel(const size_t index, const T val, const T zero,
+                                     const bool computeDensity, const int *maskCuda,
+                                     float *initDensity, bool *nanImagePtr, T *curIntensity) {
+    if (computeDensity) {
+        const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
+        const bool active = inMask && ConvVoxelActive(val);
+        initDensity[index] = active ? 1.f : 0;
+        nanImagePtr[index] = !active;
+        curIntensity[index] = active ? val : zero;
+    } else {
+        curIntensity[index] = nanImagePtr[index] ? zero : val;
+    }
+}
+/* *************************************************************** */
 // Upload the kernel weights and return the device pointer. When a workspace is available the
 // upload is skipped if the same kernel (type, radius, spacing) is already resident - consecutive
 // convolutions of one LNCC call all share the same kernel, so only the first axis pays the copy.
@@ -191,7 +221,7 @@ void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
                 double temp;
                 if (sigma[t] > 0) temp = sigma[t] / image->pixdim[n + 1];
                 else temp = fabs(sigma[t]);
-                const int radius = static_cast<int>(temp);
+                const int radius = KernelRadius<kernelType>(temp);
                 if (radius <= 0) continue;
 
                 int planeCount, lineOffset;
@@ -267,15 +297,7 @@ void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
                 float *initDensity = curDensity;
                 thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
                     const float intensityVal = reinterpret_cast<float*>(&imageCuda[index])[t];
-                    if (computeDensity) {
-                        const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
-                        const bool active = inMask && intensityVal == intensityVal;
-                        initDensity[index] = active ? 1.f : 0;
-                        nanImagePtr[index] = !active;
-                        curIntensity[index] = active ? intensityVal : 0;
-                    } else {
-                        curIntensity[index] = nanImagePtr[index] ? 0 : intensityVal;
-                    }
+                    InitConvVoxel<float>(index, intensityVal, 0.f, computeDensity, maskCuda, initDensity, nanImagePtr, curIntensity);
                 });
             }
 
@@ -285,14 +307,7 @@ void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
                 double temp;
                 if (sigma[t] > 0) temp = sigma[t] / image->pixdim[n + 1]; // mm to voxel
                 else temp = fabs(sigma[t]); // voxel-based if negative value
-                int radius = 0;
-                if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
-                    radius = static_cast<int>(temp);
-                else if constexpr (kernelType == ConvKernelType::Gaussian)
-                    radius = static_cast<int>(temp * 3.0);
-                else if constexpr (kernelType == ConvKernelType::Cubic)
-                    radius = static_cast<int>(temp * 2.0);
-                else NR_FATAL_ERROR("Unknown kernel type");
+                const int radius = KernelRadius<kernelType>(temp);
                 if (radius <= 0) continue;
 
                 // Fill the kernel (identical maths to the CPU reg_tools_kernelConvolution)
@@ -458,16 +473,8 @@ void NiftyReg::Cuda::KernelConvolutionPacked(const nifti_image *image,
     {
         float *initDensity = curDensity;
         thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
-            const float4 val = imageCuda[index];
-            if (computeDensity) {
-                const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
-                const bool active = inMask && val.x == val.x;
-                initDensity[index] = active ? 1.f : 0;
-                nanImagePtr[index] = !active;
-                curIntensity[index] = active ? val : make_float4(0, 0, 0, 0);
-            } else {
-                curIntensity[index] = nanImagePtr[index] ? make_float4(0, 0, 0, 0) : val;
-            }
+            InitConvVoxel<float4>(index, imageCuda[index], make_float4(0, 0, 0, 0),
+                                  computeDensity, maskCuda, initDensity, nanImagePtr, curIntensity);
         });
     }
 
@@ -477,14 +484,7 @@ void NiftyReg::Cuda::KernelConvolutionPacked(const nifti_image *image,
         double temp;
         if (sigma[0] > 0) temp = sigma[0] / image->pixdim[n + 1]; // mm to voxel
         else temp = fabs(sigma[0]); // voxel-based if negative value
-        int radius = 0;
-        if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
-            radius = static_cast<int>(temp);
-        else if constexpr (kernelType == ConvKernelType::Gaussian)
-            radius = static_cast<int>(temp * 3.0);
-        else if constexpr (kernelType == ConvKernelType::Cubic)
-            radius = static_cast<int>(temp * 2.0);
-        else NR_FATAL_ERROR("Unknown kernel type");
+        const int radius = KernelRadius<kernelType>(temp);
         if (radius <= 0) continue;
 
         vector<float> kernel;
@@ -593,7 +593,7 @@ void NiftyReg::Cuda::KernelConvolutionPacked(const nifti_image *image,
     const float *finalDensity = curDensity;
     thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
         if (nanImagePtr[index]) {
-            const float nan = std::numeric_limits<float>::quiet_NaN();
+            constexpr float nan = std::numeric_limits<float>::quiet_NaN();
             imageCuda[index] = make_float4(nan, nan, nan, nan);
         } else {
             const float4 val = finalIntensity[index];

--- a/reg-lib/cuda/CudaKernelConvolution.cu
+++ b/reg-lib/cuda/CudaKernelConvolution.cu
@@ -1,12 +1,104 @@
 #include "CudaKernelConvolution.hpp"
 
 /* *************************************************************** */
+void NiftyReg::Cuda::KernelConvolutionWorkspace::EnsureSize(const size_t voxelNumber, const int channels) {
+    const size_t intensitySize = voxelNumber * channels;
+    if (intensityA.size() < intensitySize) {
+        intensityA.resize(intensitySize);
+        intensityB.resize(intensitySize);
+    }
+    if (density.size() < voxelNumber) {
+        density.resize(voxelNumber);
+        densityAux.resize(voxelNumber);
+        nanImage.resize(voxelNumber);
+    }
+}
+/* *************************************************************** */
+namespace {
+/* *************************************************************** */
+using NiftyReg::Cuda::KernelConvolutionWorkspace;
+/* *************************************************************** */
+// L2 cache size of the current device (queried once); used to decide when an axis pass's sliding
+// window would overflow L2 and the column-parallel variant should be used instead.
+size_t GetL2CacheSize() {
+    static const size_t l2CacheSize = []() {
+        int device = 0, l2Size = 0;
+        cudaGetDevice(&device);
+        cudaDeviceGetAttribute(&l2Size, cudaDevAttrL2CacheSize, device);
+        return l2Size > 0 ? static_cast<size_t>(l2Size) : size_t(4) << 20;
+    }();
+    return l2CacheSize;
+}
+/* *************************************************************** */
+// Fill the kernel weights on the host (identical maths to the CPU reg_tools_kernelConvolution)
+// and return the kernel sum. Shared by the single-channel and packed convolutions.
 template<ConvKernelType kernelType>
+double ComputeKernelWeights(vector<float>& kernel, const int radius, const double temp) {
+    kernel.resize(2 * radius + 1);
+    double kernelSum = 0;
+    if constexpr (kernelType == ConvKernelType::Cubic) {
+        for (int i = -radius; i <= radius; i++) {
+            double relative = fabs(i / temp);
+            if (relative < 1.0)
+                kernel[i + radius] = static_cast<float>(2.0 / 3.0 - Square(relative) + 0.5 * Cube(relative));
+            else if (relative < 2.0)
+                kernel[i + radius] = static_cast<float>(-Cube(relative - 2.0) / 6.0);
+            else kernel[i + radius] = 0;
+            kernelSum += kernel[i + radius];
+        }
+    } else if constexpr (kernelType == ConvKernelType::Gaussian) {
+        for (int i = -radius; i <= radius; i++) {
+            kernel[i + radius] = static_cast<float>(exp(-Square(i) / (2.0 * Square(temp))) / (temp * 2.506628274631));
+            kernelSum += kernel[i + radius];
+        }
+    } else if constexpr (kernelType == ConvKernelType::Linear) {
+        for (int i = -radius; i <= radius; i++) {
+            kernel[i + radius] = 1.f - fabs(i / static_cast<float>(radius));
+            kernelSum += kernel[i + radius];
+        }
+    } else if constexpr (kernelType == ConvKernelType::Mean) {
+        // Only reached in 2D (3D Mean uses the cumulative path)
+        for (int i = -radius; i <= radius; i++) {
+            kernel[i + radius] = 1.f;
+            kernelSum += kernel[i + radius];
+        }
+    }
+    return kernelSum;
+}
+/* *************************************************************** */
+// Upload the kernel weights and return the device pointer. When a workspace is available the
+// upload is skipped if the same kernel (type, radius, spacing) is already resident - consecutive
+// convolutions of one LNCC call all share the same kernel, so only the first axis pays the copy.
+template<ConvKernelType kernelType>
+const float* UploadKernelWeights(const vector<float>& kernel, const int radius, const double temp,
+                                 KernelConvolutionWorkspace *workspace,
+                                 thrust::device_vector<float>& localKernel) {
+    if (workspace) {
+        if (workspace->cachedKernelKind != int(kernelType) ||
+            workspace->cachedKernelRadius != radius ||
+            workspace->cachedKernelTemp != temp) {
+            if (workspace->kernel.size() < kernel.size()) workspace->kernel.resize(kernel.size());
+            thrust::copy(kernel.begin(), kernel.end(), workspace->kernel.begin());
+            workspace->cachedKernelKind = int(kernelType);
+            workspace->cachedKernelRadius = radius;
+            workspace->cachedKernelTemp = temp;
+        }
+        return workspace->kernel.data().get();
+    }
+    localKernel = kernel;
+    return localKernel.data().get();
+}
+/* *************************************************************** */
+} // anonymous namespace
+/* *************************************************************** */
+template<ConvKernelType kernelType, class AccType>
 void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
                                        float4 *imageCuda,
                                        const float *sigma,
                                        const bool *timePoints,
-                                       const bool *axes) {
+                                       const bool *axes,
+                                       const int *maskCuda,
+                                       KernelConvolutionWorkspace *workspace) {
     if (image->nx > 2048 || image->ny > 2048 || image->nz > 2048)
         NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
 
@@ -26,217 +118,497 @@ void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
     const size_t voxelNumber = NiftiImage::calcVoxelNumber(image, 3);
     const int3 imageDims = make_int3(image->nx, image->ny, image->nz);
 
-    thrust::device_vector<float> densityCuda(voxelNumber);
-    thrust::device_vector<bool> nanImageCuda(voxelNumber);
-    thrust::device_vector<float> bufferIntensityCuda(voxelNumber);
-    thrust::device_vector<float> bufferDensityCuda(voxelNumber);
-    float *densityCudaPtr = densityCuda.data().get();
-    bool *nanImageCudaPtr = nanImageCuda.data().get();
-    float *bufferIntensityCudaPtr = bufferIntensityCuda.data().get();
-    float *bufferDensityCudaPtr = bufferDensityCuda.data().get();
+    // Scratch buffers: reuse the caller's workspace when provided (avoids per-call cudaMalloc/
+    // cudaFree), else allocate locally. `computeDensity` is false only when the caller has a valid
+    // cached density to reuse (see KernelConvolutionWorkspace), in which case the density is neither
+    // recomputed nor convolved and the cached smoothed density is used for the final normalisation.
+    thrust::device_vector<float> localDensity, localDensityAux, localIntensityA, localIntensityB;
+    thrust::device_vector<bool> localNanImage;
+    float *densityPtr, *densityAuxPtr, *intensityAPtr, *intensityBPtr;
+    bool *nanImagePtr;
+    bool computeDensity = true;
+    if (workspace) {
+        workspace->EnsureSize(voxelNumber);
+        densityPtr = workspace->density.data().get();
+        densityAuxPtr = workspace->densityAux.data().get();
+        nanImagePtr = workspace->nanImage.data().get();
+        intensityAPtr = workspace->intensityA.data().get();
+        intensityBPtr = workspace->intensityB.data().get();
+        computeDensity = !workspace->densityValid;
+    } else {
+        localDensity.resize(voxelNumber);
+        localDensityAux.resize(voxelNumber);
+        localNanImage.resize(voxelNumber);
+        localIntensityA.resize(voxelNumber);
+        localIntensityB.resize(voxelNumber);
+        densityPtr = localDensity.data().get();
+        densityAuxPtr = localDensityAux.data().get();
+        nanImagePtr = localNanImage.data().get();
+        intensityAPtr = localIntensityA.data().get();
+        intensityBPtr = localIntensityB.data().get();
+    }
+    // Where a cached density (computeDensity == false) is to be read from: the weighted path may
+    // have left it in either buffer (see KernelConvolutionWorkspace::densityInAux).
+    float *cachedDensityPtr = workspace && workspace->densityInAux ? densityAuxPtr : densityPtr;
 
-    // Create texture objects
-    auto imageTexturePtr = Cuda::CreateTextureObject(imageCuda, voxelNumber, cudaChannelFormatKindFloat, 1);
-    auto densityTexturePtr = Cuda::CreateTextureObject(densityCudaPtr, voxelNumber, cudaChannelFormatKindFloat, 1);
-    auto nanImageTexturePtr = Cuda::CreateTextureObject(nanImageCudaPtr, voxelNumber, cudaChannelFormatKindUnsigned, 1);
-    auto imageTexture = *imageTexturePtr;
-    auto densityTexture = *densityTexturePtr;
-    auto nanImageTexture = *nanImageTexturePtr;
+    // The cumulative (running-sum) filter is only used for the Mean kernel on 3D volumes; every
+    // other case (all non-Mean kernels, and the Mean kernel in 2D) uses a weighted sum. A single
+    // convolution never mixes the two, so the whole call takes one branch.
+    constexpr bool isMean = kernelType == ConvKernelType::Mean;
+    const bool cumulative = isMean && imageDims.z > 1;
 
     for (int t = 0; t < activeTimePointCount; t++) {
         if (!activeTimePoints[t]) continue;
 
-        thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
-            const float intensityVal = tex1Dfetch<float>(imageTexture, index * 4 + t);
-            float& densityVal = densityCudaPtr[index];
-            bool& nanImageVal = nanImageCudaPtr[index];
-            densityVal = intensityVal == intensityVal ? 1.f : 0;
-            nanImageVal = !static_cast<bool>(densityVal);
-            if (nanImageVal) reinterpret_cast<float*>(&imageCuda[index])[t] = 0;
-        });
+        if (cumulative) {
+            // Cumulative (3D Mean) path: line-parallel and in-place, unchanged from the original -
+            // the running-sum filter cannot be voxel-parallelised bit-exactly. The in-place filter
+            // works in the stable density buffer; a cached density is only read (final normalisation).
+            float *activeDensityPtr = computeDensity ? densityPtr : cachedDensityPtr;
+            auto imageTexturePtr = Cuda::CreateTextureObject(imageCuda, voxelNumber, cudaChannelFormatKindFloat, 1);
+            auto densityTexturePtr = Cuda::CreateTextureObject(activeDensityPtr, voxelNumber, cudaChannelFormatKindFloat, 1);
+            auto imageTexture = *imageTexturePtr;
+            auto densityTexture = *densityTexturePtr;
+            // Reuse intensityA/intensityB as the per-plane intensity/density line buffers
+            float *bufferIntensityCudaPtr = intensityAPtr;
+            float *bufferDensityCudaPtr = intensityBPtr;
 
-        // Loop over the x, y and z dimensions
-        for (int n = 0; n < 3; n++) {
-            if (!axesToSmooth[n] || image->dim[n] <= 1) continue;
-
-            double temp;
-            if (sigma[t] > 0) temp = sigma[t] / image->pixdim[n + 1]; // mm to voxel
-            else temp = fabs(sigma[t]); // voxel-based if negative value
-            int radius = 0;
-            // Define the kernel size
-            if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
-                radius = static_cast<int>(temp);
-            else if constexpr (kernelType == ConvKernelType::Gaussian)
-                radius = static_cast<int>(temp * 3.0);
-            else if constexpr (kernelType == ConvKernelType::Cubic)
-                radius = static_cast<int>(temp * 2.0);
-            else NR_FATAL_ERROR("Unknown kernel type");
-            if (radius <= 0) continue;
-
-            // Allocate the kernel
-            vector<float> kernel(2 * radius + 1);
-            double kernelSum = 0;
-            // Fill the kernel
-            if constexpr (kernelType == ConvKernelType::Cubic) {
-                // Compute the Cubic Spline kernel
-                for (int i = -radius; i <= radius; i++) {
-                    // temp contains the kernel node spacing
-                    double relative = fabs(i / temp);
-                    if (relative < 1.0)
-                        kernel[i + radius] = static_cast<float>(2.0 / 3.0 - Square(relative) + 0.5 * Cube(relative));
-                    else if (relative < 2.0)
-                        kernel[i + radius] = static_cast<float>(-Cube(relative - 2.0) / 6.0);
-                    else kernel[i + radius] = 0;
-                    kernelSum += kernel[i + radius];
+            thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+                if (computeDensity) {
+                    const float intensityVal = tex1Dfetch<float>(imageTexture, index * 4 + t);
+                    const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
+                    const float d = inMask && intensityVal == intensityVal ? 1.f : 0;
+                    activeDensityPtr[index] = d;
+                    nanImagePtr[index] = !static_cast<bool>(d);
+                    if (!static_cast<bool>(d)) reinterpret_cast<float*>(&imageCuda[index])[t] = 0;
+                } else {
+                    if (nanImagePtr[index]) reinterpret_cast<float*>(&imageCuda[index])[t] = 0;
                 }
-            } else if constexpr (kernelType == ConvKernelType::Gaussian) {
-                // Compute the Gaussian kernel
-                for (int i = -radius; i <= radius; i++) {
-                    // 2.506... = sqrt(2*pi)
-                    // temp contains the sigma in voxel
-                    kernel[i + radius] = static_cast<float>(exp(-Square(i) / (2.0 * Square(temp))) / (temp * 2.506628274631));
-                    kernelSum += kernel[i + radius];
-                }
-            } else if constexpr (kernelType == ConvKernelType::Linear) {
-                // Compute the linear kernel
-                for (int i = -radius; i <= radius; i++) {
-                    kernel[i + radius] = 1.f - fabs(i / static_cast<float>(radius));
-                    kernelSum += kernel[i + radius];
-                }
-            } else if constexpr (kernelType == ConvKernelType::Mean) {
-                if (imageDims.z == 1) {
-                    // Compute the mean kernel
-                    for (int i = -radius; i <= radius; i++) {
-                        kernel[i + radius] = 1.f;
-                        kernelSum += kernel[i + radius];
-                    }
-                }
-            }
-            // No kernel is required for the mean filtering
-            // No need for kernel normalisation as this is handled by the density function
-            NR_DEBUG("Convolution type[" << int(kernelType) << "] dim[" << n << "] tp[" << t << "] radius[" << radius << "] kernelSum[" << kernelSum << "]");
+            });
 
-            int planeCount, lineOffset;
-            switch (n) {
-            case 0:
-                planeCount = imageDims.y * imageDims.z;
-                lineOffset = 1;
-                break;
-            case 1:
-                planeCount = imageDims.x * imageDims.z;
-                lineOffset = imageDims.x;
-                break;
-            case 2:
-                planeCount = imageDims.x * imageDims.y;
-                lineOffset = planeCount;
-                break;
-            }
+            for (int n = 0; n < 3; n++) {
+                if (!axesToSmooth[n] || image->dim[n] <= 1) continue;
+                double temp;
+                if (sigma[t] > 0) temp = sigma[t] / image->pixdim[n + 1];
+                else temp = fabs(sigma[t]);
+                const int radius = static_cast<int>(temp);
+                if (radius <= 0) continue;
 
-            const int imageDim = reinterpret_cast<const int*>(&imageDims)[n];
-            // Create the kernel texture
-            thrust::device_vector<float> kernelCuda;
-            Cuda::UniqueTextureObjectPtr kernelTexturePtr;
-            cudaTextureObject_t kernelTexture = 0;
-            if (kernelSum > 0) {
-                kernelCuda = kernel;
-                kernelTexturePtr = Cuda::CreateTextureObject(kernelCuda.data().get(), kernel.size(), cudaChannelFormatKindFloat, 1);
-                kernelTexture = *kernelTexturePtr;
-            }
-
-            // Loop over the different voxel
-            thrust::for_each_n(thrust::device, thrust::make_counting_iterator(0), planeCount, [=]__device__(const int planeIndex) {
-                int realIndex = 0;
+                int planeCount, lineOffset;
                 switch (n) {
-                case 0:
-                    realIndex = planeIndex * imageDims.x;
-                    break;
-                case 1:
-                    realIndex = (planeIndex / imageDims.x) * imageDims.x * imageDims.y + planeIndex % imageDims.x;
-                    break;
-                case 2:
-                    realIndex = planeIndex;
-                    break;
+                case 0: planeCount = imageDims.y * imageDims.z; lineOffset = 1; break;
+                case 1: planeCount = imageDims.x * imageDims.z; lineOffset = imageDims.x; break;
+                case 2: planeCount = imageDims.x * imageDims.y; lineOffset = planeCount; break;
                 }
-                // Fetch the current line into a stack buffer
-                const auto bufferIndex = planeIndex * imageDim;
-                float *bufferIntensityPtr = &bufferIntensityCudaPtr[bufferIndex];
-                float *bufferDensityPtr = &bufferDensityCudaPtr[bufferIndex];
-                for (int lineIndex = 0, index = realIndex; lineIndex < imageDim; lineIndex++, index += lineOffset) {
-                    bufferIntensityPtr[lineIndex] = tex1Dfetch<float>(imageTexture, index * 4 + t);
-                    bufferDensityPtr[lineIndex] = tex1Dfetch<float>(densityTexture, index);
-                }
-                if (kernelSum > 0) {
-                    // Perform the kernel convolution along 1 line
-                    for (int lineIndex = 0; lineIndex < imageDim; lineIndex++, realIndex += lineOffset) {
-                        // Define the kernel boundaries
-                        int shiftPre = lineIndex - radius;
-                        int shiftPst = lineIndex + radius + 1;
-                        int kernelIndex = 0;
-                        if (shiftPre < 0) {
-                            kernelIndex = -shiftPre;
-                            shiftPre = 0;
-                        }
-                        if (shiftPst > imageDim) shiftPst = imageDim;
-                        // Set the current values to zero
-                        // Increment the current value by performing the weighted sum
-                        double intensitySum = 0, densitySum = 0;
-                        for (int k = shiftPre; k < shiftPst; k++, kernelIndex++) {
-                            const float kernelValue = tex1Dfetch<float>(kernelTexture, kernelIndex);
-                            intensitySum += kernelValue * bufferIntensityPtr[k];
-                            densitySum += kernelValue * bufferDensityPtr[k];
-                        }
-                        // Store the computed value in place
-                        reinterpret_cast<float*>(&imageCuda[realIndex])[t] = static_cast<float>(intensitySum);
-                        densityCudaPtr[realIndex] = static_cast<float>(densitySum);
-                    } // line convolution
-                } else { // kernelSum <= 0
+                const int imageDim = reinterpret_cast<const int*>(&imageDims)[n];
+
+                thrust::for_each_n(thrust::device, thrust::make_counting_iterator(0), planeCount, [=]__device__(const int planeIndex) {
+                    int realIndex = 0;
+                    switch (n) {
+                    case 0: realIndex = planeIndex * imageDims.x; break;
+                    case 1: realIndex = (planeIndex / imageDims.x) * imageDims.x * imageDims.y + planeIndex % imageDims.x; break;
+                    case 2: realIndex = planeIndex; break;
+                    }
+                    const auto bufferIndex = planeIndex * imageDim;
+                    float *bufferIntensityPtr = &bufferIntensityCudaPtr[bufferIndex];
+                    float *bufferDensityPtr = &bufferDensityCudaPtr[bufferIndex];
+                    for (int lineIndex = 0, index = realIndex; lineIndex < imageDim; lineIndex++, index += lineOffset) {
+                        bufferIntensityPtr[lineIndex] = tex1Dfetch<float>(imageTexture, index * 4 + t);
+                        if (computeDensity) bufferDensityPtr[lineIndex] = tex1Dfetch<float>(densityTexture, index);
+                    }
                     for (int lineIndex = 1; lineIndex < imageDim; lineIndex++) {
                         bufferIntensityPtr[lineIndex] += bufferIntensityPtr[lineIndex - 1];
-                        bufferDensityPtr[lineIndex] += bufferDensityPtr[lineIndex - 1];
+                        if (computeDensity) bufferDensityPtr[lineIndex] += bufferDensityPtr[lineIndex - 1];
                     }
                     int shiftPre = -radius - 1;
                     int shiftPst = radius;
                     for (int lineIndex = 0; lineIndex < imageDim; lineIndex++, shiftPre++, shiftPst++, realIndex += lineOffset) {
-                        float bufferIntensityCur, bufferDensityCur;
+                        float bufferIntensityCur, bufferDensityCur = 0;
                         if (shiftPre > -1) {
                             if (shiftPst < imageDim) {
                                 bufferIntensityCur = bufferIntensityPtr[shiftPre] - bufferIntensityPtr[shiftPst];
-                                bufferDensityCur = bufferDensityPtr[shiftPre] - bufferDensityPtr[shiftPst];
+                                if (computeDensity) bufferDensityCur = bufferDensityPtr[shiftPre] - bufferDensityPtr[shiftPst];
                             } else {
                                 bufferIntensityCur = bufferIntensityPtr[shiftPre] - bufferIntensityPtr[imageDim - 1];
-                                bufferDensityCur = bufferDensityPtr[shiftPre] - bufferDensityPtr[imageDim - 1];
+                                if (computeDensity) bufferDensityCur = bufferDensityPtr[shiftPre] - bufferDensityPtr[imageDim - 1];
                             }
                         } else {
                             if (shiftPst < imageDim) {
                                 bufferIntensityCur = -bufferIntensityPtr[shiftPst];
-                                bufferDensityCur = -bufferDensityPtr[shiftPst];
+                                if (computeDensity) bufferDensityCur = -bufferDensityPtr[shiftPst];
                             } else {
                                 bufferIntensityCur = 0;
                                 bufferDensityCur = 0;
                             }
                         }
                         reinterpret_cast<float*>(&imageCuda[realIndex])[t] = bufferIntensityCur;
-                        densityCudaPtr[realIndex] = bufferDensityCur;
-                    } // line convolution of mean filter
-                } // No kernel computation
-            }); // pixel in starting plane
-        } // axes
+                        if (computeDensity) activeDensityPtr[realIndex] = bufferDensityCur;
+                    }
+                });
+            } // axes
 
-        // Normalise per time point
+            if (workspace && computeDensity) workspace->densityInAux = false;
+
+            // Normalise (or NaN out-of-mask)
+            thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+                float *intensityPtr = &reinterpret_cast<float*>(&imageCuda[index])[t];
+                if (nanImagePtr[index]) *intensityPtr = std::numeric_limits<float>::quiet_NaN();
+                else *intensityPtr = *intensityPtr / activeDensityPtr[index];
+            });
+        } else {
+            /* Weighted (voxel-parallel) path: one thread per output voxel, reading its
+             * (2*radius+1)-tap neighbourhood directly via __ldg (overlapping reads hit the read-only
+             * cache). Intensity ping-pongs between intensityA/intensityB and density between
+             * density/densityAux; source != destination each axis, so no read-after-write hazard. */
+            float *curIntensity = intensityAPtr, *nextIntensity = intensityBPtr;
+            float *curDensity = computeDensity ? densityPtr : cachedDensityPtr;
+            float *nextDensity = curDensity == densityPtr ? densityAuxPtr : densityPtr;
+            {
+                float *initDensity = curDensity;
+                thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+                    const float intensityVal = reinterpret_cast<float*>(&imageCuda[index])[t];
+                    if (computeDensity) {
+                        const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
+                        const bool active = inMask && intensityVal == intensityVal;
+                        initDensity[index] = active ? 1.f : 0;
+                        nanImagePtr[index] = !active;
+                        curIntensity[index] = active ? intensityVal : 0;
+                    } else {
+                        curIntensity[index] = nanImagePtr[index] ? 0 : intensityVal;
+                    }
+                });
+            }
+
+            for (int n = 0; n < 3; n++) {
+                if (!axesToSmooth[n] || image->dim[n] <= 1) continue;
+
+                double temp;
+                if (sigma[t] > 0) temp = sigma[t] / image->pixdim[n + 1]; // mm to voxel
+                else temp = fabs(sigma[t]); // voxel-based if negative value
+                int radius = 0;
+                if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
+                    radius = static_cast<int>(temp);
+                else if constexpr (kernelType == ConvKernelType::Gaussian)
+                    radius = static_cast<int>(temp * 3.0);
+                else if constexpr (kernelType == ConvKernelType::Cubic)
+                    radius = static_cast<int>(temp * 2.0);
+                else NR_FATAL_ERROR("Unknown kernel type");
+                if (radius <= 0) continue;
+
+                // Fill the kernel (identical maths to the CPU reg_tools_kernelConvolution)
+                vector<float> kernel;
+                const double kernelSum = ComputeKernelWeights<kernelType>(kernel, radius, temp);
+                NR_DEBUG("Convolution type[" << int(kernelType) << "] dim[" << n << "] tp[" << t << "] radius[" << radius << "] kernelSum[" << kernelSum << "]");
+                if (kernelSum <= 0) continue; // no weighting to apply
+
+                // Upload the kernel weights (cached in the workspace when available)
+                thrust::device_vector<float> localKernel;
+                const float *kernelPtr = UploadKernelWeights<kernelType>(kernel, radius, temp, workspace, localKernel);
+
+                const int nx = imageDims.x, ny = imageDims.y;
+                const int imageDim = reinterpret_cast<const int*>(&imageDims)[n];
+                const size_t stride = n == 0 ? 1 : (n == 1 ? (size_t)nx : (size_t)nx * ny);
+                const float *srcIntensity = curIntensity, *srcDensity = curDensity;
+                float *dstIntensity = nextIntensity, *dstDensity = nextDensity;
+                const bool doDensity = computeDensity;
+
+                // See the packed variant: when the z pass's (2*radius+1)-plane sliding window
+                // overflows L2, march one thread per (x,y) column along z instead of one thread per
+                // voxel - identical per-voxel tap order, so bit-for-bit the same result.
+                const size_t slidingWindowBytes = static_cast<size_t>(2 * radius + 1) * nx * ny
+                    * (doDensity ? 2 : 1) * sizeof(float);
+                const bool columnParallel = n == 2 && slidingWindowBytes > GetL2CacheSize() / 2;
+
+                if (columnParallel) {
+                    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), (size_t)nx * ny, [=]__device__(const size_t lineStart) {
+                        for (int linePos = 0; linePos < imageDim; ++linePos) {
+                            const size_t index = lineStart + static_cast<size_t>(linePos) * stride;
+                            int shiftPre = linePos - radius;
+                            int shiftPst = linePos + radius + 1;
+                            int kernelIndex = 0;
+                            if (shiftPre < 0) { kernelIndex = -shiftPre; shiftPre = 0; }
+                            if (shiftPst > imageDim) shiftPst = imageDim;
+                            AccType intensitySum = 0, densitySum = 0;
+                            for (int k = shiftPre; k < shiftPst; k++, kernelIndex++) {
+                                const float kernelValue = kernelPtr[kernelIndex];
+                                const size_t idx = lineStart + static_cast<size_t>(k) * stride;
+                                intensitySum += kernelValue * __ldg(&srcIntensity[idx]);
+                                if (doDensity) densitySum += kernelValue * __ldg(&srcDensity[idx]);
+                            }
+                            dstIntensity[index] = static_cast<float>(intensitySum);
+                            if (doDensity) dstDensity[index] = static_cast<float>(densitySum);
+                        }
+                    });
+                } else
+                thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+                    // Position of this voxel along the current axis and the start of its line
+                    int linePos;
+                    size_t lineStart;
+                    if (n == 0) {
+                        linePos = static_cast<int>(index % nx);
+                        lineStart = index - linePos;
+                    } else if (n == 1) {
+                        const int x = static_cast<int>(index % nx);
+                        const size_t rem = index / nx;
+                        linePos = static_cast<int>(rem % ny);
+                        const int z = static_cast<int>(rem / ny);
+                        lineStart = static_cast<size_t>(x) + static_cast<size_t>(z) * nx * ny;
+                    } else {
+                        const size_t plane = (size_t)nx * ny;
+                        linePos = static_cast<int>(index / plane);
+                        lineStart = index % plane;
+                    }
+                    int shiftPre = linePos - radius;
+                    int shiftPst = linePos + radius + 1;
+                    int kernelIndex = 0;
+                    if (shiftPre < 0) { kernelIndex = -shiftPre; shiftPre = 0; }
+                    if (shiftPst > imageDim) shiftPst = imageDim;
+                    // AccType (double by default, float for LNCC) - matches the CPU accumulation
+                    AccType intensitySum = 0, densitySum = 0;
+                    for (int k = shiftPre; k < shiftPst; k++, kernelIndex++) {
+                        const float kernelValue = kernelPtr[kernelIndex];
+                        const size_t idx = lineStart + static_cast<size_t>(k) * stride;
+                        intensitySum += kernelValue * __ldg(&srcIntensity[idx]);
+                        if (doDensity) densitySum += kernelValue * __ldg(&srcDensity[idx]);
+                    }
+                    dstIntensity[index] = static_cast<float>(intensitySum);
+                    if (doDensity) dstDensity[index] = static_cast<float>(densitySum);
+                });
+
+                std::swap(curIntensity, nextIntensity);
+                if (computeDensity) std::swap(curDensity, nextDensity);
+            } // axes
+
+            // Record which buffer holds the smoothed density (avoids a whole-volume copy; the
+            // location is honoured by subsequent density-reusing convolutions via densityInAux)
+            if (workspace && computeDensity) workspace->densityInAux = curDensity == densityAuxPtr;
+
+            // Normalise (or NaN out-of-mask)
+            const float *finalIntensity = curIntensity;
+            const float *finalDensity = curDensity;
+            thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+                float *intensityPtr = &reinterpret_cast<float*>(&imageCuda[index])[t];
+                if (nanImagePtr[index]) *intensityPtr = std::numeric_limits<float>::quiet_NaN();
+                else *intensityPtr = finalIntensity[index] / finalDensity[index];
+            });
+        } // weighted path
+    } // check if the time point is active
+
+    // The workspace now holds the smoothed density and NaN mask for this call's mask; a subsequent
+    // convolution sharing the same density can reuse them (the caller resets densityValid when the
+    // mask/density changes).
+    if (workspace)
+        workspace->densityValid = true;
+}
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Mean, double>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Linear, double>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Gaussian, double>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Cubic, double>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+// float-accumulation variants (used by LNCC for a faster, still CPU-bit-exact convolution)
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Mean, float>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Linear, float>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Gaussian, float>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Cubic, float>(const nifti_image*, float4*, const float*, const bool*, const bool*, const int*, KernelConvolutionWorkspace*);
+/* *************************************************************** */
+template<ConvKernelType kernelType, class AccType>
+void NiftyReg::Cuda::KernelConvolutionPacked(const nifti_image *image,
+                                             float4 *imageCuda,
+                                             const float *sigma,
+                                             const int *maskCuda,
+                                             KernelConvolutionWorkspace *workspace) {
+    if (!workspace)
+        NR_FATAL_ERROR("KernelConvolutionPacked requires a workspace");
+    if (image->nx > 2048 || image->ny > 2048 || image->nz > 2048)
+        NR_FATAL_ERROR("This function does not support images with dimensions larger than 2048");
+
+    constexpr bool isMean = kernelType == ConvKernelType::Mean;
+    if (isMean && image->nz > 1) {
+        // The cumulative (running-sum) 3D-Mean filter cannot be voxel-parallelised bit-exactly, so
+        // fall back to the single-channel path applied per channel. Presenting a four-time-point
+        // header makes it walk the four float4 components, each with the same sigma.
+        nifti_image header = *image; // shallow copy: the convolution only reads the geometry fields
+        header.nt = header.dim[4] = 4;
+        header.nu = header.dim[5] = 1;
+        const float sigma4[4]{ sigma[0], sigma[0], sigma[0], sigma[0] };
+        KernelConvolution<kernelType, AccType>(&header, imageCuda, sigma4, nullptr, nullptr, maskCuda, workspace);
+        return;
+    }
+
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(image, 3);
+    const int3 imageDims = make_int3(image->nx, image->ny, image->nz);
+
+    workspace->EnsureSize(voxelNumber, 4);
+    float4 *intensityAPtr = reinterpret_cast<float4*>(workspace->intensityA.data().get());
+    float4 *intensityBPtr = reinterpret_cast<float4*>(workspace->intensityB.data().get());
+    float *densityPtr = workspace->density.data().get();
+    float *densityAuxPtr = workspace->densityAux.data().get();
+    bool *nanImagePtr = workspace->nanImage.data().get();
+    const bool computeDensity = !workspace->densityValid;
+
+    // The four channels share one density (see the header contract: identical mask/NaN pattern
+    // across channels, with the density derived from lane .x), so the density work is exactly that
+    // of a single-channel convolution and the cached density remains reusable either way.
+    float4 *curIntensity = intensityAPtr, *nextIntensity = intensityBPtr;
+    float *curDensity = computeDensity ? densityPtr
+                                       : (workspace->densityInAux ? densityAuxPtr : densityPtr);
+    float *nextDensity = curDensity == densityPtr ? densityAuxPtr : densityPtr;
+
+    // Initialise the working buffer: zero out-of-density voxels (all lanes - the NaN pattern is
+    // shared across channels) and, when required, compute the density and NaN mask from lane .x.
+    {
+        float *initDensity = curDensity;
         thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
-            const bool nanImageVal = tex1Dfetch<char>(nanImageTexture, index);
-            if (nanImageVal) {
-                reinterpret_cast<float*>(&imageCuda[index])[t] = std::numeric_limits<float>::quiet_NaN();
+            const float4 val = imageCuda[index];
+            if (computeDensity) {
+                const bool inMask = maskCuda == nullptr || maskCuda[index] >= 0;
+                const bool active = inMask && val.x == val.x;
+                initDensity[index] = active ? 1.f : 0;
+                nanImagePtr[index] = !active;
+                curIntensity[index] = active ? val : make_float4(0, 0, 0, 0);
             } else {
-                const float intensityVal = tex1Dfetch<float>(imageTexture, index * 4 + t);
-                const float densityVal = tex1Dfetch<float>(densityTexture, index);
-                reinterpret_cast<float*>(&imageCuda[index])[t] = intensityVal / densityVal;
+                curIntensity[index] = nanImagePtr[index] ? make_float4(0, 0, 0, 0) : val;
             }
         });
-    } // check if the time point is active
+    }
+
+    for (int n = 0; n < 3; n++) {
+        if (image->dim[n] <= 1) continue;
+
+        double temp;
+        if (sigma[0] > 0) temp = sigma[0] / image->pixdim[n + 1]; // mm to voxel
+        else temp = fabs(sigma[0]); // voxel-based if negative value
+        int radius = 0;
+        if constexpr (kernelType == ConvKernelType::Mean || kernelType == ConvKernelType::Linear)
+            radius = static_cast<int>(temp);
+        else if constexpr (kernelType == ConvKernelType::Gaussian)
+            radius = static_cast<int>(temp * 3.0);
+        else if constexpr (kernelType == ConvKernelType::Cubic)
+            radius = static_cast<int>(temp * 2.0);
+        else NR_FATAL_ERROR("Unknown kernel type");
+        if (radius <= 0) continue;
+
+        vector<float> kernel;
+        const double kernelSum = ComputeKernelWeights<kernelType>(kernel, radius, temp);
+        NR_DEBUG("Packed convolution type[" << int(kernelType) << "] dim[" << n << "] radius[" << radius << "] kernelSum[" << kernelSum << "]");
+        if (kernelSum <= 0) continue; // no weighting to apply
+
+        thrust::device_vector<float> localKernel;
+        const float *kernelPtr = UploadKernelWeights<kernelType>(kernel, radius, temp, workspace, localKernel);
+
+        const int nx = imageDims.x, ny = imageDims.y;
+        const int imageDim = reinterpret_cast<const int*>(&imageDims)[n];
+        const size_t stride = n == 0 ? 1 : (n == 1 ? (size_t)nx : (size_t)nx * ny);
+        const float4 *srcIntensity = curIntensity;
+        const float *srcDensity = curDensity;
+        float4 *dstIntensity = nextIntensity;
+        float *dstDensity = nextDensity;
+        const bool doDensity = computeDensity;
+
+        // The z pass reads taps a whole plane apart: in voxel-parallel order its cache working set
+        // is (2*radius+1) planes of float4, which overflows L2 on large volumes and makes every tap
+        // a DRAM access (measured ~17x slower at 256^3). When that window does not fit, march one
+        // thread per (x,y) column along z instead: each thread then re-reads only its own taps,
+        // whose live set (a block's columns x kernel width) stays cache-resident. The per-voxel tap
+        // order is identical in both variants, so the results are bit-for-bit the same either way.
+        const size_t slidingWindowBytes = static_cast<size_t>(2 * radius + 1) * nx * ny
+            * (sizeof(float4) + (doDensity ? sizeof(float) : 0));
+        const bool columnParallel = n == 2 && slidingWindowBytes > GetL2CacheSize() / 2;
+
+        if (columnParallel) {
+            thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), (size_t)nx * ny, [=]__device__(const size_t lineStart) {
+                for (int linePos = 0; linePos < imageDim; ++linePos) {
+                    const size_t index = lineStart + static_cast<size_t>(linePos) * stride;
+                    int shiftPre = linePos - radius;
+                    int shiftPst = linePos + radius + 1;
+                    int kernelIndex = 0;
+                    if (shiftPre < 0) { kernelIndex = -shiftPre; shiftPre = 0; }
+                    if (shiftPst > imageDim) shiftPst = imageDim;
+                    AccType sumX = 0, sumY = 0, sumZ = 0, sumW = 0, densitySum = 0;
+                    for (int k = shiftPre; k < shiftPst; k++, kernelIndex++) {
+                        const float kernelValue = kernelPtr[kernelIndex];
+                        const size_t idx = lineStart + static_cast<size_t>(k) * stride;
+                        const float4 val = __ldg(&srcIntensity[idx]);
+                        sumX += kernelValue * val.x;
+                        sumY += kernelValue * val.y;
+                        sumZ += kernelValue * val.z;
+                        sumW += kernelValue * val.w;
+                        if (doDensity) densitySum += kernelValue * __ldg(&srcDensity[idx]);
+                    }
+                    dstIntensity[index] = make_float4(static_cast<float>(sumX), static_cast<float>(sumY),
+                                                      static_cast<float>(sumZ), static_cast<float>(sumW));
+                    if (doDensity) dstDensity[index] = static_cast<float>(densitySum);
+                }
+            });
+        } else
+        thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+            // Position of this voxel along the current axis and the start of its line
+            int linePos;
+            size_t lineStart;
+            if (n == 0) {
+                linePos = static_cast<int>(index % nx);
+                lineStart = index - linePos;
+            } else if (n == 1) {
+                const int x = static_cast<int>(index % nx);
+                const size_t rem = index / nx;
+                linePos = static_cast<int>(rem % ny);
+                const int z = static_cast<int>(rem / ny);
+                lineStart = static_cast<size_t>(x) + static_cast<size_t>(z) * nx * ny;
+            } else {
+                const size_t plane = (size_t)nx * ny;
+                linePos = static_cast<int>(index / plane);
+                lineStart = index % plane;
+            }
+            int shiftPre = linePos - radius;
+            int shiftPst = linePos + radius + 1;
+            int kernelIndex = 0;
+            if (shiftPre < 0) { kernelIndex = -shiftPre; shiftPre = 0; }
+            if (shiftPst > imageDim) shiftPst = imageDim;
+            // Four independent accumulations, each in the same tap order as a single-channel
+            // convolution of that lane - hence bit-exact per lane
+            AccType sumX = 0, sumY = 0, sumZ = 0, sumW = 0, densitySum = 0;
+            for (int k = shiftPre; k < shiftPst; k++, kernelIndex++) {
+                const float kernelValue = kernelPtr[kernelIndex];
+                const size_t idx = lineStart + static_cast<size_t>(k) * stride;
+                const float4 val = __ldg(&srcIntensity[idx]);
+                sumX += kernelValue * val.x;
+                sumY += kernelValue * val.y;
+                sumZ += kernelValue * val.z;
+                sumW += kernelValue * val.w;
+                if (doDensity) densitySum += kernelValue * __ldg(&srcDensity[idx]);
+            }
+            dstIntensity[index] = make_float4(static_cast<float>(sumX), static_cast<float>(sumY),
+                                              static_cast<float>(sumZ), static_cast<float>(sumW));
+            if (doDensity) dstDensity[index] = static_cast<float>(densitySum);
+        });
+
+        std::swap(curIntensity, nextIntensity);
+        if (computeDensity) std::swap(curDensity, nextDensity);
+    } // axes
+
+    // Record which buffer holds the smoothed density (no copy needed; readers follow densityInAux)
+    if (computeDensity) workspace->densityInAux = curDensity == densityAuxPtr;
+
+    // Normalise (or NaN out-of-mask)
+    const float4 *finalIntensity = curIntensity;
+    const float *finalDensity = curDensity;
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
+        if (nanImagePtr[index]) {
+            const float nan = std::numeric_limits<float>::quiet_NaN();
+            imageCuda[index] = make_float4(nan, nan, nan, nan);
+        } else {
+            const float4 val = finalIntensity[index];
+            const float density = finalDensity[index];
+            imageCuda[index] = make_float4(val.x / density, val.y / density,
+                                           val.z / density, val.w / density);
+        }
+    });
+
+    workspace->densityValid = true;
 }
-template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Mean>(const nifti_image*, float4*, const float*, const bool*, const bool*);
-template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Linear>(const nifti_image*, float4*, const float*, const bool*, const bool*);
-template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Gaussian>(const nifti_image*, float4*, const float*, const bool*, const bool*);
-template void NiftyReg::Cuda::KernelConvolution<ConvKernelType::Cubic>(const nifti_image*, float4*, const float*, const bool*, const bool*);
+// Only the float-accumulation variants are instantiated: LNCC is the sole caller (see the header
+// contract) and uses float accumulation throughout.
+template void NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Mean, float>(const nifti_image*, float4*, const float*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Linear, float>(const nifti_image*, float4*, const float*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Gaussian, float>(const nifti_image*, float4*, const float*, const int*, KernelConvolutionWorkspace*);
+template void NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Cubic, float>(const nifti_image*, float4*, const float*, const int*, KernelConvolutionWorkspace*);
 /* *************************************************************** */

--- a/reg-lib/cuda/CudaKernelConvolution.cu
+++ b/reg-lib/cuda/CudaKernelConvolution.cu
@@ -82,7 +82,7 @@ __device__ inline bool ConvVoxelActive(const float val) { return val == val; }
 __device__ inline bool ConvVoxelActive(const float4 val) { return val.x == val.x; }
 /* *************************************************************** */
 template<class T>
-__device__ inline void InitConvVoxel(const size_t index, const T val, const T zero,
+__device__ inline void InitConvVoxel(const size_t index, const T val,
                                      const bool computeDensity, const int *maskCuda,
                                      float *initDensity, bool *nanImagePtr, T *curIntensity) {
     if (computeDensity) {
@@ -90,9 +90,9 @@ __device__ inline void InitConvVoxel(const size_t index, const T val, const T ze
         const bool active = inMask && ConvVoxelActive(val);
         initDensity[index] = active ? 1.f : 0;
         nanImagePtr[index] = !active;
-        curIntensity[index] = active ? val : zero;
+        curIntensity[index] = active ? val : T{};
     } else {
-        curIntensity[index] = nanImagePtr[index] ? zero : val;
+        curIntensity[index] = nanImagePtr[index] ? T{} : val;
     }
 }
 /* *************************************************************** */
@@ -297,7 +297,7 @@ void NiftyReg::Cuda::KernelConvolution(const nifti_image *image,
                 float *initDensity = curDensity;
                 thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
                     const float intensityVal = reinterpret_cast<float*>(&imageCuda[index])[t];
-                    InitConvVoxel<float>(index, intensityVal, 0.f, computeDensity, maskCuda, initDensity, nanImagePtr, curIntensity);
+                    InitConvVoxel<float>(index, intensityVal, computeDensity, maskCuda, initDensity, nanImagePtr, curIntensity);
                 });
             }
 
@@ -473,8 +473,8 @@ void NiftyReg::Cuda::KernelConvolutionPacked(const nifti_image *image,
     {
         float *initDensity = curDensity;
         thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber, [=]__device__(const size_t index) {
-            InitConvVoxel<float4>(index, imageCuda[index], make_float4(0, 0, 0, 0),
-                                  computeDensity, maskCuda, initDensity, nanImagePtr, curIntensity);
+            InitConvVoxel<float4>(index, imageCuda[index], computeDensity, maskCuda,
+                                  initDensity, nanImagePtr, curIntensity);
         });
     }
 

--- a/reg-lib/cuda/CudaKernelConvolution.hpp
+++ b/reg-lib/cuda/CudaKernelConvolution.hpp
@@ -5,6 +5,49 @@
 /* *************************************************************** */
 namespace NiftyReg::Cuda {
 /* *************************************************************** */
+/** @brief Reusable device scratch for KernelConvolution.
+ *
+ * Passing the same workspace to repeated convolutions avoids re-allocating the internal
+ * buffers on every call - a significant host-side (cudaMalloc/cudaFree) overhead when a routine
+ * convolves many images per iteration (e.g. LNCC runs five convolutions per similarity value).
+ *
+ * It can additionally cache the smoothed density field: when @c densityValid is true the next
+ * convolution reuses the cached @c density / @c nanImage instead of recomputing them. The caller
+ * is responsible for only keeping @c densityValid true across convolutions that genuinely share
+ * the same density - i.e. the same mask, with every in-mask voxel finite in every image. The LNCC
+ * scratch images qualify (their combined mask already excludes every NaN voxel), so the density is
+ * identical for all of them and need only be computed once.
+ */
+struct KernelConvolutionWorkspace {
+    // The weighted (Gaussian/Cubic/Linear, and 2D-Mean) path is voxel-parallel and ping-pongs the
+    // intensity between intensityA/intensityB and the density between density/densityAux (the
+    // buffer holding the final smoothed density is recorded in densityInAux). The cumulative
+    // (3D-Mean) path is line-parallel and in-place, reusing intensityA/intensityB as its per-plane
+    // intensity/density scratch.
+    thrust::device_vector<float> density;
+    thrust::device_vector<float> densityAux;
+    thrust::device_vector<bool> nanImage;
+    thrust::device_vector<float> intensityA;
+    thrust::device_vector<float> intensityB;
+    thrust::device_vector<float> kernel;
+    bool densityValid = false;
+    /// True when the cached smoothed density lives in densityAux rather than density (the weighted
+    /// path ping-pongs between the two, so with an odd number of smoothed axes it ends in the aux
+    /// buffer; tracking the location avoids a whole-volume copy per density computation).
+    bool densityInAux = false;
+    // Key of the kernel weights currently uploaded in `kernel`, so consecutive convolutions with
+    // the same kernel (as in LNCC, where every convolution of a call shares sigma and type) skip
+    // the per-axis host-to-device upload. cachedKernelKind is int(ConvKernelType) or -1.
+    int cachedKernelKind = -1;
+    int cachedKernelRadius = -1;
+    double cachedKernelTemp = -1;
+    /// Grow the buffers so the intensity ping-pong holds at least @p voxelNumber * @p channels
+    /// floats and the density/NaN buffers hold @p voxelNumber elements (never shrinks).
+    /// Defined in CudaKernelConvolution.cu so device_vector::resize is only ever instantiated by
+    /// the device compiler (host translation units that merely see this type must not trigger it).
+    void EnsureSize(const size_t voxelNumber, const int channels = 1);
+};
+/* *************************************************************** */
 /** @brief Smooth an image using a specified kernel
  * @param image Image to be smoothed
  * @param imageCuda Image to be smoothed
@@ -15,13 +58,53 @@ namespace NiftyReg::Cuda {
  * smoothed. The array follow the dim array of the nifti header.
  * @param axes Boolean array to specify which axes have to be
  * smoothed. The array follow the dim array of the nifti header.
+ * @param maskCuda Optional per-voxel mask (device pointer). When provided, a voxel
+ * contributes to the convolution only if maskCuda[voxel] >= 0, mirroring the CPU
+ * reg_tools_kernelConvolution density behaviour. When nullptr (default) all
+ * non-NaN voxels are active, preserving the previous behaviour.
+ * @param workspace Optional reusable scratch (see KernelConvolutionWorkspace). When nullptr the
+ * buffers are allocated locally for this call and the density is always recomputed (the default,
+ * unchanged behaviour). When provided, the buffers are reused and the smoothed density may be
+ * cached/reused across calls (controlled by workspace->densityValid).
+ *
+ * @tparam AccType Precision of the per-line weighted-sum accumulation. Defaults to double (matching
+ * the CPU reg_tools_kernelConvolution, so the result is bit-exact with it). LNCC uses float to move
+ * the accumulation off the (slow on some GPUs) FP64 pipe
  */
-template<ConvKernelType kernelType>
+template<ConvKernelType kernelType, class AccType = double>
 void KernelConvolution(const nifti_image *image,
                        float4 *imageCuda,
                        const float *sigma,
                        const bool *timePoints = nullptr,
-                       const bool *axes = nullptr);
+                       const bool *axes = nullptr,
+                       const int *maskCuda = nullptr,
+                       KernelConvolutionWorkspace *workspace = nullptr);
+/* *************************************************************** */
+/** @brief Smooth all four channels of a float4 image in a single pass.
+ *
+ * Same maths as KernelConvolution applied to each float4 component independently: per voxel and
+ * per channel the tap order, accumulation type and normalisation are identical to convolving that
+ * channel alone, so the per-channel results are bit-for-bit the same as four single-channel calls.
+ * Packing four images into one float4 volume and using this function instead of four calls
+ * quarters the kernel launches and the elementwise init/normalise passes, and turns the strided
+ * one-float-in-sixteen-bytes accesses of a `.x`-only image into fully coalesced float4 accesses.
+ *
+ * Requirements (all satisfied by the LNCC scratch images, the only caller):
+ *  - @p image describes the 3D geometry only; every channel is smoothed with sigma[0].
+ *  - The mask/NaN pattern must be identical across channels (the shared density is derived from
+ *    channel .x): every in-mask voxel must be finite in every channel. Out-of-mask lanes may hold
+ *    any garbage - lanes never mix.
+ *  - @p workspace is mandatory (it provides the float4-sized scratch and the density cache).
+ *
+ * The cumulative 3D-Mean filter cannot be voxel-parallelised, so for that case this function
+ * falls back to the (bit-identical) single-channel path applied per channel.
+ */
+template<ConvKernelType kernelType, class AccType = double>
+void KernelConvolutionPacked(const nifti_image *image,
+                             float4 *imageCuda,
+                             const float *sigma,
+                             const int *maskCuda,
+                             KernelConvolutionWorkspace *workspace);
 /* *************************************************************** */
 }
 /* *************************************************************** */

--- a/reg-lib/cuda/CudaLocalTransformation.cu
+++ b/reg-lib/cuda/CudaLocalTransformation.cu
@@ -18,6 +18,35 @@
 /* *************************************************************** */
 namespace NiftyReg::Cuda {
 /* *************************************************************** */
+const int* ExponentiationWorkspace::GetIdentityMask(const size_t voxelNumber) {
+    // The identity mask [0, 1, ...) is constant, so only (re)fill it when it must grow.
+    if (mask.size() < voxelNumber) {
+        mask.resize(voxelNumber);
+        thrust::sequence(mask.begin(), mask.end());
+    }
+    return mask.data().get();
+}
+/* *************************************************************** */
+float4* ExponentiationWorkspace::GetFlowField(const size_t voxelNumber) {
+    if (flowField.size() < voxelNumber)
+        flowField.resize(voxelNumber);
+    // GetFlowFieldFromVelocityGrid seeds the field as an identity displacement (all zeros) before
+    // adding the spline component, so the buffer must start zeroed - matching the freshly allocated
+    // (value-initialised) device_vector the non-workspace path uses. Reused buffers hold stale data,
+    // so zero the active range here.
+    cudaMemset(flowField.data().get(), 0, voxelNumber * sizeof(float4));
+    return flowField.data().get();
+}
+/* *************************************************************** */
+vector<thrust::device_vector<float4>>& ExponentiationWorkspace::GetIntermediates(const size_t count, const size_t voxelNumber) {
+    if (intermediates.size() < count)
+        intermediates.resize(count);
+    for (auto& v : intermediates)
+        if (v.size() < voxelNumber)
+            v.resize(voxelNumber);
+    return intermediates;
+}
+/* *************************************************************** */
 template<bool composition, bool bspline>
 void GetDeformationField(const nifti_image *controlPointImage,
                          const nifti_image *referenceImage,
@@ -647,6 +676,27 @@ void DefFieldCompose(const nifti_image *deformationField,
         DefFieldComposeKernel<is3d>(deformationFieldOutCuda, deformationFieldTexture, referenceImageDims, affineMatrixB, affineMatrixC, index);
     });
 }
+template void DefFieldCompose<true>(const nifti_image*, const float4*, float4*);
+template void DefFieldCompose<false>(const nifti_image*, const float4*, float4*);
+/* *************************************************************** */
+// Ping-pong composition for the scaling-and-squaring loops: the sampling positions and the lookup
+// table are the SAME source field (given by srcTexture), and the squared field is written to a
+// distinct output buffer, so no field copy-back is needed between steps. The caller supplies the
+// texture (created once for a buffer that is reused across every step, avoiding per-step texture
+// creation). Bit-identical to DefFieldCompose applied to a field composed with itself.
+template<bool is3d>
+static void DefFieldComposePingPong(const nifti_image *deformationField,
+                                    cudaTextureObject_t srcTexture,
+                                    float4 *deformationFieldOutCuda) {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(deformationField, 3);
+    const int3 referenceImageDims{ deformationField->nx, deformationField->ny, deformationField->nz };
+    const mat44& affineMatrixB = deformationField->sform_code > 0 ? deformationField->sto_ijk : deformationField->qto_ijk;
+    const mat44& affineMatrixC = deformationField->sform_code > 0 ? deformationField->sto_xyz : deformationField->qto_xyz;
+
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator(0), voxelNumber, [=]__device__(const int index) {
+        DefFieldComposeKernel<is3d, true>(deformationFieldOutCuda, srcTexture, referenceImageDims, affineMatrixB, affineMatrixC, index);
+    });
+}
 /* *************************************************************** */
 void GetDeformationFieldFromFlowField(nifti_image *flowField,
                                       nifti_image *deformationField,
@@ -704,18 +754,20 @@ void GetDeformationFieldFromFlowField(nifti_image *flowField,
     // Conversion from displacement to deformation
     GetDeformationFromDisplacement(flowField, flowFieldCuda);
 
-    // The computed scaled deformation field is copied over
-    thrust::copy(thrust::device, flowFieldCuda, flowFieldCuda + voxelNumber, deformationFieldCuda);
-
-    // The deformation field is squared
-    auto defFieldCompose = deformationField->nz > 1 ? DefFieldCompose<true> : DefFieldCompose<false>;
+    auto defFieldComposePingPong = deformationField->nz > 1 ? DefFieldComposePingPong<true> : DefFieldComposePingPong<false>;
+    auto flowTexturePtr = Cuda::CreateTextureObject(flowFieldCuda, voxelNumber, cudaChannelFormatKindFloat, 4);
+    auto defTexturePtr = Cuda::CreateTextureObject(deformationFieldCuda, voxelNumber, cudaChannelFormatKindFloat, 4);
+    float4 *curCuda = flowFieldCuda, *nextCuda = deformationFieldCuda;
+    cudaTextureObject_t curTexture = *flowTexturePtr, nextTexture = *defTexturePtr;
     for (int i = 0; i < squaringNumber; ++i) {
-        // The deformation field is applied to itself
-        defFieldCompose(deformationField, deformationFieldCuda, flowFieldCuda);
-        // The computed scaled deformation field is copied over
-        thrust::copy_n(thrust::device, flowFieldCuda, voxelNumber, deformationFieldCuda);
+        defFieldComposePingPong(deformationField, curTexture, nextCuda);
+        std::swap(curCuda, nextCuda);
+        std::swap(curTexture, nextTexture);
         NR_DEBUG("Squaring (composition) step " << i + 1 << "/" << squaringNumber);
     }
+    // Ensure the result ends up in deformationFieldCuda (one copy at most, vs one per step above)
+    if (curCuda != deformationFieldCuda)
+        thrust::copy_n(thrust::device, curCuda, voxelNumber, deformationFieldCuda);
     // The affine component of the transformation is restored
     if (!affineOnlyCudaVec.empty()) {
         GetDisplacementFromDeformation(deformationField, deformationFieldCuda);
@@ -733,12 +785,20 @@ void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,
                                  nifti_image *deformationField,
                                  float4 *velocityFieldGridCuda,
                                  float4 *deformationFieldCuda,
-                                 const bool updateStepNumber) {
+                                 const bool updateStepNumber,
+                                 ExponentiationWorkspace *workspace) {
     const size_t voxelNumber = NiftiImage::calcVoxelNumber(deformationField, 3);
 
-    // Create a mask array where no voxel is excluded
-    thrust::device_vector<int> maskCudaVec(voxelNumber);
-    thrust::sequence(maskCudaVec.begin(), maskCudaVec.end());
+    // Identity mask (no voxel excluded); reused from the workspace when provided, else built here
+    thrust::device_vector<int> localMask;
+    const int *maskCuda;
+    if (workspace) {
+        maskCuda = workspace->GetIdentityMask(voxelNumber);
+    } else {
+        localMask.resize(voxelNumber);
+        thrust::sequence(localMask.begin(), localMask.end());
+        maskCuda = localMask.data().get();
+    }
 
     // Clean any extension in the deformation field as it is unexpected
     nifti_free_extensions(deformationField);
@@ -750,7 +810,7 @@ void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,
                                          deformationField,
                                          velocityFieldGridCuda,
                                          deformationFieldCuda,
-                                         maskCudaVec.data().get(),
+                                         maskCuda,
                                          voxelNumber);
     } else if (velocityFieldGrid->intent_p1 == SPLINE_VEL_GRID) {
         // Create an image to store the flow field
@@ -762,14 +822,21 @@ void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,
         if (velocityFieldGrid->num_ext > 0)
             nifti_copy_extensions(flowField, velocityFieldGrid);
 
-        // Allocate CUDA memory for the flow field
-        thrust::device_vector<float4> flowFieldCudaVec(voxelNumber);
+        // Flow-field scratch: reused from the workspace when provided, else allocated here
+        thrust::device_vector<float4> localFlowField;
+        float4 *flowFieldCuda;
+        if (workspace) {
+            flowFieldCuda = workspace->GetFlowField(voxelNumber);
+        } else {
+            localFlowField.resize(voxelNumber);
+            flowFieldCuda = localFlowField.data().get();
+        }
 
         // Generate the velocity field
         GetFlowFieldFromVelocityGrid(velocityFieldGrid, flowField, velocityFieldGridCuda,
-                                     flowFieldCudaVec.data().get(), maskCudaVec.data().get(), voxelNumber);
+                                     flowFieldCuda, maskCuda, voxelNumber);
         // Exponentiate the flow field
-        GetDeformationFieldFromFlowField(flowField, deformationField, flowFieldCudaVec.data().get(),
+        GetDeformationFieldFromFlowField(flowField, deformationField, flowFieldCuda,
                                          deformationFieldCuda, updateStepNumber);
         // Update the number of step required. No action otherwise
         velocityFieldGrid->intent_p2 = flowField->intent_p2;
@@ -779,14 +846,22 @@ void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,
 void GetIntermediateDefFieldFromVelGrid(nifti_image *velocityFieldGrid,
                                         float4 *velocityFieldGridCuda,
                                         vector<NiftiImage>& deformationFields,
-                                        vector<thrust::device_vector<float4>>& deformationFieldCudaVecs) {
+                                        vector<thrust::device_vector<float4>>& deformationFieldCudaVecs,
+                                        ExponentiationWorkspace *workspace) {
     if (velocityFieldGrid->intent_p1 != SPLINE_VEL_GRID)
         NR_FATAL_ERROR("The provided input image is not a spline parametrised transformation");
 
-    // Create a mask array where no voxel is excluded
+    // Identity mask (no voxel excluded); reused from the workspace when provided
     const size_t voxelNumber = deformationFields[0].nVoxelsPerVolume();
-    thrust::device_vector<int> maskCudaVec(voxelNumber);
-    thrust::sequence(maskCudaVec.begin(), maskCudaVec.end());
+    thrust::device_vector<int> localMask;
+    const int *maskCuda;
+    if (workspace) {
+        maskCuda = workspace->GetIdentityMask(voxelNumber);
+    } else {
+        localMask.resize(voxelNumber);
+        thrust::sequence(localMask.begin(), localMask.end());
+        maskCuda = localMask.data().get();
+    }
 
     // Create an image to store the flow field
     NiftiImage flowField(deformationFields[0], NiftiImage::Copy::ImageInfo);
@@ -797,13 +872,19 @@ void GetIntermediateDefFieldFromVelGrid(nifti_image *velocityFieldGrid,
     if (velocityFieldGrid->num_ext > 0)
         nifti_copy_extensions(flowField, velocityFieldGrid);
 
-    // Allocate CUDA memory for the flow field
-    thrust::device_vector<float4> flowFieldCudaVec(voxelNumber);
-    auto flowFieldCuda = flowFieldCudaVec.data().get();
+    // Flow-field scratch: reused from the workspace when provided
+    thrust::device_vector<float4> localFlowField;
+    float4 *flowFieldCuda;
+    if (workspace) {
+        flowFieldCuda = workspace->GetFlowField(voxelNumber);
+    } else {
+        localFlowField.resize(voxelNumber);
+        flowFieldCuda = localFlowField.data().get();
+    }
 
     // Generate the velocity field
     GetFlowFieldFromVelocityGrid(velocityFieldGrid, flowField, velocityFieldGridCuda,
-                                 flowFieldCuda, maskCudaVec.data().get(), voxelNumber);
+                                 flowFieldCuda, maskCuda, voxelNumber);
 
     // Remove the affine component from the flow field
     NiftiImage affineOnly;
@@ -831,13 +912,15 @@ void GetIntermediateDefFieldFromVelGrid(nifti_image *velocityFieldGrid,
     // Conversion from displacement to deformation
     GetDeformationFromDisplacement(deformationFields[0], deformationFieldCudaVecs[0].data().get());
 
-    // The deformation field is squared
-    auto defFieldCompose = deformationFields[0]->nz > 1 ? DefFieldCompose<true> : DefFieldCompose<false>;
+    // The deformation field is squared. Each intermediate field (vec[i+1] = vec[i] composed with
+    // itself) must be kept for the gradient exponentiation, so the buffers cannot be ping-ponged;
+    // but the per-step copy-back is still removed by reading the sampling positions from vec[i]'s
+    // texture (positions == lookup == vec[i]) and writing directly into the distinct vec[i+1].
+    auto defFieldComposePingPong = deformationFields[0]->nz > 1 ? DefFieldComposePingPong<true> : DefFieldComposePingPong<false>;
     for (int i = 0; i < squaringNumber; i++) {
-        // The computed scaled deformation field is copied over
-        thrust::copy_n(thrust::device, deformationFieldCudaVecs[i].data().get(), voxelNumber, deformationFieldCudaVecs[i + 1].data().get());
-        // The deformation field is applied to itself
-        defFieldCompose(deformationFields[i], deformationFieldCudaVecs[i].data().get(), deformationFieldCudaVecs[i + 1].data().get());
+        auto srcTexturePtr = Cuda::CreateTextureObject(deformationFieldCudaVecs[i].data().get(), voxelNumber, cudaChannelFormatKindFloat, 4);
+        // vec[i+1] = vec[i](vec[i])
+        defFieldComposePingPong(deformationFields[i], *srcTexturePtr, deformationFieldCudaVecs[i + 1].data().get());
         NR_DEBUG("Squaring (composition) step " << i + 1 << "/" << squaringNumber);
     }
 

--- a/reg-lib/cuda/CudaLocalTransformation.hpp
+++ b/reg-lib/cuda/CudaLocalTransformation.hpp
@@ -71,15 +71,18 @@ void DefFieldCompose(const nifti_image *deformationField,
  * and reused. Buffers only ever grow.
  */
 struct ExponentiationWorkspace {
-    thrust::device_vector<int> mask;                       // identity mask (filled once per size)
-    thrust::device_vector<float4> flowField;               // flow-field scratch
-    vector<thrust::device_vector<float4>> intermediates;   // gradient path: squaringNumber+1 fields
+public:
     /// Identity mask [0, 1, ...voxelNumber); (re)filled only when it must grow.
     const int* GetIdentityMask(const size_t voxelNumber);
     /// Flow-field scratch of at least voxelNumber float4 (grows only).
     float4* GetFlowField(const size_t voxelNumber);
     /// Ensure `count` intermediate buffers each holding at least voxelNumber float4 (grows only).
     vector<thrust::device_vector<float4>>& GetIntermediates(const size_t count, const size_t voxelNumber);
+
+private:
+    thrust::device_vector<int> mask;                       // identity mask (filled once per size)
+    thrust::device_vector<float4> flowField;               // flow-field scratch
+    vector<thrust::device_vector<float4>> intermediates;   // gradient path: squaringNumber+1 fields
 };
 /* *************************************************************** */
 void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,

--- a/reg-lib/cuda/CudaLocalTransformation.hpp
+++ b/reg-lib/cuda/CudaLocalTransformation.hpp
@@ -61,16 +61,39 @@ void DefFieldCompose(const nifti_image *deformationField,
                      const float4 *deformationFieldCuda,
                      float4 *deformationFieldOutCuda);
 /* *************************************************************** */
+/** @brief Reusable device scratch for the velocity-field exponentiation.
+ *
+ * The scaling-and-squaring exponentiation runs on every objective-function evaluation (forward and
+ * backward, plus every line-search probe) and every gradient step, each time allocating and freeing
+ * the flow-field buffer and an identity mask (and, for the gradient path, the intermediate fields).
+ * Passing a persistent workspace removes that per-call cudaMalloc/cudaFree churn (a large host-side
+ * cost in profiling). The identity mask is a constant [0, 1, 2, ...] sequence, so it is filled once
+ * and reused. Buffers only ever grow.
+ */
+struct ExponentiationWorkspace {
+    thrust::device_vector<int> mask;                       // identity mask (filled once per size)
+    thrust::device_vector<float4> flowField;               // flow-field scratch
+    vector<thrust::device_vector<float4>> intermediates;   // gradient path: squaringNumber+1 fields
+    /// Identity mask [0, 1, ...voxelNumber); (re)filled only when it must grow.
+    const int* GetIdentityMask(const size_t voxelNumber);
+    /// Flow-field scratch of at least voxelNumber float4 (grows only).
+    float4* GetFlowField(const size_t voxelNumber);
+    /// Ensure `count` intermediate buffers each holding at least voxelNumber float4 (grows only).
+    vector<thrust::device_vector<float4>>& GetIntermediates(const size_t count, const size_t voxelNumber);
+};
+/* *************************************************************** */
 void GetDefFieldFromVelocityGrid(nifti_image *velocityFieldGrid,
                                  nifti_image *deformationField,
                                  float4 *velocityFieldGridCuda,
                                  float4 *deformationFieldCuda,
-                                 const bool updateStepNumber);
+                                 const bool updateStepNumber,
+                                 ExponentiationWorkspace *workspace = nullptr);
 /* *************************************************************** */
 void GetIntermediateDefFieldFromVelGrid(nifti_image *velocityFieldGrid,
                                         float4 *velocityFieldGridCuda,
                                         vector<NiftiImage>& deformationFields,
-                                        vector<thrust::device_vector<float4>>& deformationFieldCudaVecs);
+                                        vector<thrust::device_vector<float4>>& deformationFieldCudaVecs,
+                                        ExponentiationWorkspace *workspace = nullptr);
 /* *************************************************************** */
 template<bool is3d>
 double ApproxLinearEnergy(const nifti_image *controlPointGrid,

--- a/reg-lib/cuda/CudaLocalTransformationKernels.cu
+++ b/reg-lib/cuda/CudaLocalTransformationKernels.cu
@@ -1133,7 +1133,11 @@ __global__ void CorrectFolding3d(float4 *controlPointGrid,
     }
 }
 /* *************************************************************** */
-template<bool is3d>
+// pingPong: when false (default) the sampling position is read from the output buffer and the
+// result written back in place (used for a standalone composition). When true the position is read
+// from the lookup buffer via its texture (positions == lookup == the source field) and the result
+// written to a distinct output buffer, so the scaling-and-squaring loop can alternate two buffers.
+template<bool is3d, bool pingPong = false>
 __device__ void DefFieldComposeKernel(float4 *deformationField,
                                       cudaTextureObject_t deformationFieldTexture,
                                       const int3 referenceImageDims,
@@ -1141,7 +1145,7 @@ __device__ void DefFieldComposeKernel(float4 *deformationField,
                                       const mat44 affineMatrixC,
                                       const int index) {
     // Extract the original voxel position
-    float4 position = deformationField[index];
+    float4 position = pingPong ? tex1Dfetch<float4>(deformationFieldTexture, index) : deformationField[index];
 
     if constexpr (is3d) {
         // Conversion from real position to voxel coordinate

--- a/reg-lib/cuda/CudaMeasureCreator.cpp
+++ b/reg-lib/cuda/CudaMeasureCreator.cpp
@@ -1,5 +1,6 @@
 #include "CudaMeasureCreator.hpp"
 #include "CudaDefContent.h"
+#include "_reg_lncc_gpu.h"
 #include "_reg_nmi_gpu.h"
 #include "_reg_ssd_gpu.h"
 
@@ -52,6 +53,7 @@ void CudaMeasureCreator::Initialise(reg_measure& measure, DefContent& con, DefCo
                                  cudaConBw ? static_cast<nifti_image*>(cudaConBw->DefContent::GetWarpedGradient()) : nullptr,
                                  cudaConBw ? cudaConBw->GetWarpedGradientCuda() : nullptr,
                                  cudaConBw ? static_cast<nifti_image*>(cudaConBw->DefContent::GetVoxelBasedMeasureGradient()) : nullptr,
-                                 cudaConBw ? cudaConBw->GetVoxelBasedMeasureGradientCuda() : nullptr);
+                                 cudaConBw ? cudaConBw->GetVoxelBasedMeasureGradientCuda() : nullptr,
+                                 cudaConBw ? cudaConBw->GetActiveVoxelNumber() : 0);
 }
 /* *************************************************************** */

--- a/reg-lib/cuda/_reg_lncc_gpu.cu
+++ b/reg-lib/cuda/_reg_lncc_gpu.cu
@@ -1,0 +1,428 @@
+/*
+ * @file _reg_lncc_gpu.cu
+ * @author Marc Modat
+ * @date 10/11/2012
+ *
+ *  Copyright (c) 2009-2018, University College London
+ *  Copyright (c) 2018, NiftyReg Developers.
+ *  All rights reserved.
+ * See the LICENSE.txt file in the nifty_reg root folder
+ *
+ */
+
+#include "_reg_lncc_gpu.h"
+#include "CudaKernelConvolution.hpp"
+
+/* *************************************************************** */
+reg_lncc_gpu::reg_lncc_gpu(): reg_lncc::reg_lncc() {
+    NR_FUNC_CALLED();
+}
+/* *************************************************************** */
+reg_lncc_gpu::~reg_lncc_gpu() {
+    NR_FUNC_CALLED();
+}
+/* *************************************************************** */
+void reg_lncc_gpu::InitialiseMeasure(nifti_image *refImg, float *refImgCuda,
+                                     nifti_image *floImg, float *floImgCuda,
+                                     int *refMask, int *refMaskCuda,
+                                     size_t activeVoxNum,
+                                     nifti_image *warpedImg, float *warpedImgCuda,
+                                     nifti_image *warpedGrad, float4 *warpedGradCuda,
+                                     nifti_image *voxelBasedGrad, float4 *voxelBasedGradCuda,
+                                     nifti_image *localWeightSim, float *localWeightSimCuda,
+                                     int *floMask, int *floMaskCuda,
+                                     nifti_image *warpedImgBw, float *warpedImgBwCuda,
+                                     nifti_image *warpedGradBw, float4 *warpedGradBwCuda,
+                                     nifti_image *voxelBasedGradBw, float4 *voxelBasedGradBwCuda,
+                                     size_t activeVoxNumBw) {
+    // The CPU initialisation allocates the nifti scratch headers (mean/sdev/correlation and
+    // their Bw counterparts) and rescales the reference/floating intensities to [0, 1]
+    reg_lncc::InitialiseMeasure(refImg, floImg, refMask, warpedImg, warpedGrad, voxelBasedGrad,
+                                localWeightSim, floMask, warpedImgBw, warpedGradBw, voxelBasedGradBw);
+    reg_measure_gpu::InitialiseMeasure(refImg, refImgCuda, floImg, floImgCuda, refMask, refMaskCuda, activeVoxNum,
+                                       warpedImg, warpedImgCuda, warpedGrad, warpedGradCuda, voxelBasedGrad, voxelBasedGradCuda,
+                                       localWeightSim, localWeightSimCuda, floMask, floMaskCuda, warpedImgBw, warpedImgBwCuda,
+                                       warpedGradBw, warpedGradBwCuda, voxelBasedGradBw, voxelBasedGradBwCuda, activeVoxNumBw);
+
+    // reg_lncc::InitialiseMeasure rescaled the reference and floating intensities on the host,
+    // so the device copies must be refreshed (mirrors reg_ssd_gpu for normalised time points).
+    // The floating image must be up to date before the warped image is (re)computed on the device.
+    Cuda::TransferNiftiToDevice(this->referenceImageCuda, this->referenceImage);
+    Cuda::TransferNiftiToDevice(this->floatingImageCuda, this->floatingImage);
+
+    // Allocate the device scratch buffers (see _reg_lncc_gpu.h for the lane layout) and upload
+    // the per-voxel host mask once - the per-call combined-mask build is then a pure device pass
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(this->referenceImage, 3);
+    this->statsImageCuda.resize(voxelNumber);
+    this->correlationImageCuda.resize(voxelNumber);
+    this->forwardMaskCuda.resize(voxelNumber);
+    this->baseMaskCuda.resize(voxelNumber);
+    thrust::copy_n(this->referenceMask, voxelNumber, this->baseMaskCuda.begin());
+    if (this->isSymmetric) {
+        const size_t voxelNumberBw = NiftiImage::calcVoxelNumber(this->floatingImage, 3);
+        this->statsImageBwCuda.resize(voxelNumberBw);
+        this->correlationImageBwCuda.resize(voxelNumberBw);
+        this->backwardMaskCuda.resize(voxelNumberBw);
+        this->baseMaskBwCuda.resize(voxelNumberBw);
+        thrust::copy_n(this->floatingMask, voxelNumberBw, this->baseMaskBwCuda.begin());
+    }
+    NR_FUNC_CALLED();
+}
+/* *************************************************************** */
+namespace {
+/* *************************************************************** */
+// Runtime dispatch to the compile-time templated packed convolution (all four float4 lanes in one
+// pass). LNCC accumulates in float (not double)
+void ConvolvePacked(const nifti_image *image, float4 *imageCuda, const float *sigma,
+                    const ConvKernelType kernelType, const int *maskCuda,
+                    NiftyReg::Cuda::KernelConvolutionWorkspace *workspace) {
+    switch (kernelType) {
+    case ConvKernelType::Mean:
+        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Mean, float>(image, imageCuda, sigma, maskCuda, workspace);
+        break;
+    case ConvKernelType::Linear:
+        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Linear, float>(image, imageCuda, sigma, maskCuda, workspace);
+        break;
+    case ConvKernelType::Gaussian:
+        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Gaussian, float>(image, imageCuda, sigma, maskCuda, workspace);
+        break;
+    case ConvKernelType::Cubic:
+        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Cubic, float>(image, imageCuda, sigma, maskCuda, workspace);
+        break;
+    default:
+        NR_FATAL_ERROR("Unsupported kernel type");
+    }
+}
+/* *************************************************************** */
+// Single-channel (.x) dispatch, used for the correlation image: a packed pass would read 16 bytes
+// per tap for one useful lane, whose larger cache footprint hurts at large volume sizes, whereas
+// the single-channel axis kernels work on compact float scratch (4 bytes per tap).
+void Convolve(const nifti_image *image, float4 *imageCuda, const float *sigma,
+              const ConvKernelType kernelType, const int *maskCuda,
+              NiftyReg::Cuda::KernelConvolutionWorkspace *workspace) {
+    switch (kernelType) {
+    case ConvKernelType::Mean:
+        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Mean, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
+        break;
+    case ConvKernelType::Linear:
+        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Linear, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
+        break;
+    case ConvKernelType::Gaussian:
+        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Gaussian, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
+        break;
+    case ConvKernelType::Cubic:
+        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Cubic, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
+        break;
+    default:
+        NR_FATAL_ERROR("Unsupported kernel type");
+    }
+}
+/* *************************************************************** */
+// Build the per-voxel combined mask on the device in a single pass: start from the device-resident
+// base mask (reg_measure convention: value >= 0 when active, -1 otherwise) and remove every voxel
+// that is NaN in the reference or warped image at any time point, mirroring the CPU
+// memcpy(combinedMask, refMask) + reg_tools_removeNanFromMask sequence in UpdateLocalStatImages.
+void BuildCombinedMask(const int *baseMaskCuda, int *combinedMaskCuda, const size_t voxelNumber,
+                       const float *referenceImageCuda, const float *warpedImageCuda,
+                       const int referenceTimePoints) {
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber,
+                       [=]__device__(const size_t index) {
+        int value = baseMaskCuda[index];
+        for (int t = 0; t < referenceTimePoints; ++t) {
+            const float refVal = referenceImageCuda[t * voxelNumber + index];
+            const float warVal = warpedImageCuda[t * voxelNumber + index];
+            if (refVal != refVal || warVal != warVal) {
+                value = -1;
+                break;
+            }
+        }
+        combinedMaskCuda[index] = value;
+    });
+}
+/* *************************************************************** */
+// Port of UpdateLocalStatImages (_reg_lncc.cpp). Fills the packed stats image with the raw
+// (pre-finalisation) smoothed statistics for the given time point: x = G*I, y = G*(I^2),
+// z = G*J, w = G*(J^2). Per lane the convolution is bit-identical to smoothing each CPU image.
+void UpdateLocalStatImages_gpu(const nifti_image *image,
+                               const float *referenceImageCuda,
+                               const float *warpedImageCuda,
+                               float4 *statsImageCuda,
+                               const int *combinedMaskCuda,
+                               const float *kernelStandardDeviation,
+                               const ConvKernelType kernelType,
+                               const int currentTimePoint,
+                               NiftyReg::Cuda::KernelConvolutionWorkspace& workspace) {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(image, 3);
+    const float *refPtr = referenceImageCuda + currentTimePoint * voxelNumber;
+    const float *warPtr = warpedImageCuda + currentTimePoint * voxelNumber;
+
+    // The combined mask (hence the smoothed density) is the same for every convolution of this
+    // call, so the packed convolution computes the density once and the correlation/gradient
+    // convolutions that follow reuse it.
+    workspace.densityValid = false;
+
+    // stats = (I, I^2, J, J^2)
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber,
+                       [=]__device__(const size_t index) {
+        const float refVal = refPtr[index];
+        const float warVal = warPtr[index];
+        statsImageCuda[index] = make_float4(refVal, refVal * refVal, warVal, warVal * warVal);
+    });
+
+    ConvolvePacked(image, statsImageCuda, kernelStandardDeviation, kernelType, combinedMaskCuda, &workspace);
+}
+/* *************************************************************** */
+// Finalise the smoothed statistics (sdev = sqrt(G*(I^2) - (G*I)^2), stabilised - identical float
+// expressions to the CPU) and, in the same pass, initialise the correlation image with ref * war.
+void FinaliseStatsInitCorrelation(const size_t voxelNumber,
+                                  float4 *statsImageCuda,
+                                  float4 *correlationImageCuda,
+                                  const float *refPtr,
+                                  const float *warPtr) {
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber,
+                       [=]__device__(const size_t index) {
+        const float4 stats = statsImageCuda[index];
+        float sdev = sqrtf(stats.y - stats.x * stats.x);
+        if (sdev < 1.e-06) sdev = 0;
+        float warSdev = sqrtf(stats.w - stats.z * stats.z);
+        if (warSdev < 1.e-06) warSdev = 0;
+        statsImageCuda[index] = make_float4(stats.x, sdev, stats.z, warSdev);
+        correlationImageCuda[index] = make_float4(refPtr[index] * warPtr[index], 0, 0, 0);
+    });
+}
+/* *************************************************************** */
+// Port of reg_getLnccValue (_reg_lncc.cpp) for a single time point.
+double GetLnccValue_gpu(const nifti_image *image,
+                        const float *referenceImageCuda,
+                        const float *warpedImageCuda,
+                        float4 *statsImageCuda,
+                        float4 *correlationImageCuda,
+                        const int *combinedMaskCuda,
+                        const float *kernelStandardDeviation,
+                        const ConvKernelType kernelType,
+                        const int currentTimePoint,
+                        NiftyReg::Cuda::KernelConvolutionWorkspace& workspace) {
+    UpdateLocalStatImages_gpu(image, referenceImageCuda, warpedImageCuda, statsImageCuda,
+                              combinedMaskCuda, kernelStandardDeviation, kernelType, currentTimePoint, workspace);
+
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(image, 3);
+    const float *refPtr = referenceImageCuda + currentTimePoint * voxelNumber;
+    const float *warPtr = warpedImageCuda + currentTimePoint * voxelNumber;
+
+    FinaliseStatsInitCorrelation(voxelNumber, statsImageCuda, correlationImageCuda, refPtr, warPtr);
+    // correlation = G*(ref * war); reuses the density cached by the stats convolution
+    Convolve(image, correlationImageCuda, kernelStandardDeviation, kernelType, combinedMaskCuda, &workspace);
+
+    // Sum |lncc| over the active voxels where the value is finite; also count them
+    const double2 lnccSumAndCount = thrust::transform_reduce(thrust::device,
+        thrust::make_counting_iterator<size_t>(0), thrust::make_counting_iterator<size_t>(voxelNumber),
+        [=]__device__(const size_t index) -> double2 {
+            if (combinedMaskCuda[index] > -1) {
+                // Mirror the CPU float arithmetic exactly before widening to double
+                const float4 stats = statsImageCuda[index];
+                const float num = correlationImageCuda[index].x - stats.x * stats.z;
+                const float den = stats.y * stats.w;
+                const float lncc = num / den;
+                if (lncc == lncc && !isinf(lncc))
+                    return make_double2(fabs(static_cast<double>(lncc)), 1.0);
+            }
+            return make_double2(0, 0);
+        }, make_double2(0, 0), thrust::plus<double2>());
+
+    return lnccSumAndCount.x / lnccSumAndCount.y;
+}
+/* *************************************************************** */
+// Port of reg_getVoxelBasedLnccGradient (_reg_lncc.cpp) for a single time point.
+void GetVoxelBasedLnccGradient_gpu(const nifti_image *image,
+                                   const bool is3d,
+                                   const float *referenceImageCuda,
+                                   const float *warpedImageCuda,
+                                   float4 *statsImageCuda,
+                                   float4 *correlationImageCuda,
+                                   const float4 *warpedGradientCuda,
+                                   float4 *voxelBasedGradientCuda,
+                                   const int *combinedMaskCuda,
+                                   const float *kernelStandardDeviation,
+                                   const ConvKernelType kernelType,
+                                   const int currentTimePoint,
+                                   const double timePointWeight,
+                                   NiftyReg::Cuda::KernelConvolutionWorkspace& workspace) {
+    UpdateLocalStatImages_gpu(image, referenceImageCuda, warpedImageCuda, statsImageCuda,
+                              combinedMaskCuda, kernelStandardDeviation, kernelType, currentTimePoint, workspace);
+
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(image, 3);
+    const float *refPtr = referenceImageCuda + currentTimePoint * voxelNumber;
+    const float *warPtr = warpedImageCuda + currentTimePoint * voxelNumber;
+
+    FinaliseStatsInitCorrelation(voxelNumber, statsImageCuda, correlationImageCuda, refPtr, warPtr);
+    // correlation = G*(ref * war); reuses the density cached by the stats convolution
+    Convolve(image, correlationImageCuda, kernelStandardDeviation, kernelType, combinedMaskCuda, &workspace);
+
+    // Compute temp1/temp2/temp3 (identical double expressions to the CPU), store them into the
+    // correlation image lanes x/y/z for the subsequent packed smoothing, and count the voxels
+    // that contribute a finite gradient term - a single pass replacing the previous
+    // count_if + store passes (matches the CPU activeVoxelNumber exactly: an integer count is
+    // reduction-order independent).
+    const size_t activeVoxelNumber = thrust::transform_reduce(thrust::device,
+        thrust::make_counting_iterator<size_t>(0), thrust::make_counting_iterator<size_t>(voxelNumber),
+        [=]__device__(const size_t index) -> size_t {
+            if (combinedMaskCuda[index] > -1) {
+                const float4 stats = statsImageCuda[index];
+                const double refMeanValue = stats.x;
+                const double warMeanValue = stats.z;
+                const double refSdevValue = stats.y;
+                const double warSdevValue = stats.w;
+                const double correlaValue = static_cast<double>(correlationImageCuda[index].x) - (refMeanValue * warMeanValue);
+                double temp1 = 1.0 / (refSdevValue * warSdevValue);
+                double temp2 = correlaValue / (refSdevValue * warSdevValue * warSdevValue * warSdevValue);
+                double temp3 = (correlaValue * warMeanValue) / (refSdevValue * warSdevValue * warSdevValue * warSdevValue)
+                    - refMeanValue / (refSdevValue * warSdevValue);
+                if (temp1 == temp1 && !isinf(temp1) &&
+                    temp2 == temp2 && !isinf(temp2) &&
+                    temp3 == temp3 && !isinf(temp3)) {
+                    // Derivative of the absolute function
+                    if (correlaValue < 0) {
+                        temp1 *= -1;
+                        temp2 *= -1;
+                        temp3 *= -1;
+                    }
+                    correlationImageCuda[index] = make_float4(static_cast<float>(temp1),
+                                                              static_cast<float>(temp2),
+                                                              static_cast<float>(temp3), 0);
+                    return 1;
+                }
+            }
+            correlationImageCuda[index] = make_float4(0, 0, 0, 0);
+            return 0;
+        }, size_t(0), thrust::plus<size_t>());
+
+    const double adjustedWeight = timePointWeight / activeVoxelNumber;
+
+    // Smooth the three temp fields in one packed pass (same combined mask, so the cached density
+    // is reused; lane w carries zeros)
+    ConvolvePacked(image, correlationImageCuda, kernelStandardDeviation, kernelType, combinedMaskCuda, &workspace);
+
+    // Accumulate the gradient
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber,
+                       [=]__device__(const size_t index) {
+        if (combinedMaskCuda[index] > -1) {
+            const float4 temps = correlationImageCuda[index];
+            const float inner = temps.x * refPtr[index]
+                - temps.y * warPtr[index]
+                + temps.z;
+            const double common = static_cast<double>(inner) * adjustedWeight;
+            const float4 warpGradient = warpedGradientCuda[index];
+            float4 measureGradient = voxelBasedGradientCuda[index];
+            measureGradient.x -= static_cast<float>(warpGradient.x * common);
+            measureGradient.y -= static_cast<float>(warpGradient.y * common);
+            if (is3d)
+                measureGradient.z -= static_cast<float>(warpGradient.z * common);
+            voxelBasedGradientCuda[index] = measureGradient;
+        }
+    });
+
+    // Zero out any NaN/Inf produced in the gradient
+    thrust::for_each_n(thrust::device, thrust::make_counting_iterator<size_t>(0), voxelNumber,
+                       [=]__device__(const size_t index) {
+        float4 measureGradient = voxelBasedGradientCuda[index];
+        if (measureGradient.x != measureGradient.x || isinf(measureGradient.x)) measureGradient.x = 0;
+        if (measureGradient.y != measureGradient.y || isinf(measureGradient.y)) measureGradient.y = 0;
+        if (is3d && (measureGradient.z != measureGradient.z || isinf(measureGradient.z))) measureGradient.z = 0;
+        voxelBasedGradientCuda[index] = measureGradient;
+    });
+}
+/* *************************************************************** */
+} // anonymous namespace
+/* *************************************************************** */
+double reg_lncc_gpu::GetSimilarityMeasureValueFw() {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(this->referenceImage, 3);
+    int *combinedMaskCuda = this->forwardMaskCuda.data().get();
+    BuildCombinedMask(this->baseMaskCuda.data().get(), combinedMaskCuda, voxelNumber,
+                      this->referenceImageCuda, this->warpedImageCuda, this->referenceTimePoints);
+
+    double lncc = 0;
+    for (int currentTimePoint = 0; currentTimePoint < this->referenceTimePoints; ++currentTimePoint) {
+        if (this->timePointWeights[currentTimePoint] > 0) {
+            const double tp = GetLnccValue_gpu(this->correlationImage,
+                                               this->referenceImageCuda,
+                                               this->warpedImageCuda,
+                                               this->statsImageCuda.data().get(),
+                                               this->correlationImageCuda.data().get(),
+                                               combinedMaskCuda,
+                                               this->kernelStandardDeviation,
+                                               this->kernelType,
+                                               currentTimePoint,
+                                               this->convWorkspace);
+            lncc += tp * this->timePointWeights[currentTimePoint];
+        }
+    }
+    return lncc;
+}
+/* *************************************************************** */
+double reg_lncc_gpu::GetSimilarityMeasureValueBw() {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(this->floatingImage, 3);
+    int *combinedMaskCuda = this->backwardMaskCuda.data().get();
+    BuildCombinedMask(this->baseMaskBwCuda.data().get(), combinedMaskCuda, voxelNumber,
+                      this->floatingImageCuda, this->warpedImageBwCuda, this->referenceTimePoints);
+
+    double lncc = 0;
+    for (int currentTimePoint = 0; currentTimePoint < this->referenceTimePoints; ++currentTimePoint) {
+        if (this->timePointWeights[currentTimePoint] > 0) {
+            const double tp = GetLnccValue_gpu(this->correlationImageBw,
+                                               this->floatingImageCuda,
+                                               this->warpedImageBwCuda,
+                                               this->statsImageBwCuda.data().get(),
+                                               this->correlationImageBwCuda.data().get(),
+                                               combinedMaskCuda,
+                                               this->kernelStandardDeviation,
+                                               this->kernelType,
+                                               currentTimePoint,
+                                               this->convWorkspace);
+            lncc += tp * this->timePointWeights[currentTimePoint];
+        }
+    }
+    return lncc;
+}
+/* *************************************************************** */
+void reg_lncc_gpu::GetVoxelBasedSimilarityMeasureGradientFw(int currentTimePoint) {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(this->referenceImage, 3);
+    int *combinedMaskCuda = this->forwardMaskCuda.data().get();
+    BuildCombinedMask(this->baseMaskCuda.data().get(), combinedMaskCuda, voxelNumber,
+                      this->referenceImageCuda, this->warpedImageCuda, this->referenceTimePoints);
+    GetVoxelBasedLnccGradient_gpu(this->correlationImage,
+                                  this->referenceImage->nz > 1,
+                                  this->referenceImageCuda,
+                                  this->warpedImageCuda,
+                                  this->statsImageCuda.data().get(),
+                                  this->correlationImageCuda.data().get(),
+                                  this->warpedGradientCuda,
+                                  this->voxelBasedGradientCuda,
+                                  combinedMaskCuda,
+                                  this->kernelStandardDeviation,
+                                  this->kernelType,
+                                  currentTimePoint,
+                                  this->timePointWeights[currentTimePoint],
+                                  this->convWorkspace);
+}
+/* *************************************************************** */
+void reg_lncc_gpu::GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint) {
+    const size_t voxelNumber = NiftiImage::calcVoxelNumber(this->floatingImage, 3);
+    int *combinedMaskCuda = this->backwardMaskCuda.data().get();
+    BuildCombinedMask(this->baseMaskBwCuda.data().get(), combinedMaskCuda, voxelNumber,
+                      this->floatingImageCuda, this->warpedImageBwCuda, this->referenceTimePoints);
+    GetVoxelBasedLnccGradient_gpu(this->correlationImageBw,
+                                  this->floatingImage->nz > 1,
+                                  this->floatingImageCuda,
+                                  this->warpedImageBwCuda,
+                                  this->statsImageBwCuda.data().get(),
+                                  this->correlationImageBwCuda.data().get(),
+                                  this->warpedGradientBwCuda,
+                                  this->voxelBasedGradientBwCuda,
+                                  combinedMaskCuda,
+                                  this->kernelStandardDeviation,
+                                  this->kernelType,
+                                  currentTimePoint,
+                                  this->timePointWeights[currentTimePoint],
+                                  this->convWorkspace);
+}
+/* *************************************************************** */

--- a/reg-lib/cuda/_reg_lncc_gpu.cu
+++ b/reg-lib/cuda/_reg_lncc_gpu.cu
@@ -1,15 +1,3 @@
-/*
- * @file _reg_lncc_gpu.cu
- * @author Marc Modat
- * @date 10/11/2012
- *
- *  Copyright (c) 2009-2018, University College London
- *  Copyright (c) 2018, NiftyReg Developers.
- *  All rights reserved.
- * See the LICENSE.txt file in the nifty_reg root folder
- *
- */
-
 #include "_reg_lncc_gpu.h"
 #include "CudaKernelConvolution.hpp"
 
@@ -71,27 +59,25 @@ void reg_lncc_gpu::InitialiseMeasure(nifti_image *refImg, float *refImgCuda,
 /* *************************************************************** */
 namespace {
 /* *************************************************************** */
+template<class F>
+void DispatchKernelType(const ConvKernelType kernelType, F&& f) {
+    switch (kernelType) {
+    case ConvKernelType::Mean:     f(std::integral_constant<ConvKernelType, ConvKernelType::Mean>{});     break;
+    case ConvKernelType::Linear:   f(std::integral_constant<ConvKernelType, ConvKernelType::Linear>{});   break;
+    case ConvKernelType::Gaussian: f(std::integral_constant<ConvKernelType, ConvKernelType::Gaussian>{}); break;
+    case ConvKernelType::Cubic:    f(std::integral_constant<ConvKernelType, ConvKernelType::Cubic>{});    break;
+    default:                       NR_FATAL_ERROR("Unsupported kernel type");
+    }
+}
+/* *************************************************************** */
 // Runtime dispatch to the compile-time templated packed convolution (all four float4 lanes in one
 // pass). LNCC accumulates in float (not double)
 void ConvolvePacked(const nifti_image *image, float4 *imageCuda, const float *sigma,
                     const ConvKernelType kernelType, const int *maskCuda,
                     NiftyReg::Cuda::KernelConvolutionWorkspace *workspace) {
-    switch (kernelType) {
-    case ConvKernelType::Mean:
-        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Mean, float>(image, imageCuda, sigma, maskCuda, workspace);
-        break;
-    case ConvKernelType::Linear:
-        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Linear, float>(image, imageCuda, sigma, maskCuda, workspace);
-        break;
-    case ConvKernelType::Gaussian:
-        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Gaussian, float>(image, imageCuda, sigma, maskCuda, workspace);
-        break;
-    case ConvKernelType::Cubic:
-        NiftyReg::Cuda::KernelConvolutionPacked<ConvKernelType::Cubic, float>(image, imageCuda, sigma, maskCuda, workspace);
-        break;
-    default:
-        NR_FATAL_ERROR("Unsupported kernel type");
-    }
+    DispatchKernelType(kernelType, [&](auto kt) {
+        NiftyReg::Cuda::KernelConvolutionPacked<decltype(kt)::value, float>(image, imageCuda, sigma, maskCuda, workspace);
+    });
 }
 /* *************************************************************** */
 // Single-channel (.x) dispatch, used for the correlation image: a packed pass would read 16 bytes
@@ -100,22 +86,9 @@ void ConvolvePacked(const nifti_image *image, float4 *imageCuda, const float *si
 void Convolve(const nifti_image *image, float4 *imageCuda, const float *sigma,
               const ConvKernelType kernelType, const int *maskCuda,
               NiftyReg::Cuda::KernelConvolutionWorkspace *workspace) {
-    switch (kernelType) {
-    case ConvKernelType::Mean:
-        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Mean, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
-        break;
-    case ConvKernelType::Linear:
-        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Linear, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
-        break;
-    case ConvKernelType::Gaussian:
-        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Gaussian, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
-        break;
-    case ConvKernelType::Cubic:
-        NiftyReg::Cuda::KernelConvolution<ConvKernelType::Cubic, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
-        break;
-    default:
-        NR_FATAL_ERROR("Unsupported kernel type");
-    }
+    DispatchKernelType(kernelType, [&](auto kt) {
+        NiftyReg::Cuda::KernelConvolution<decltype(kt)::value, float>(image, imageCuda, sigma, nullptr, nullptr, maskCuda, workspace);
+    });
 }
 /* *************************************************************** */
 // Build the per-voxel combined mask on the device in a single pass: start from the device-resident

--- a/reg-lib/cuda/_reg_lncc_gpu.h
+++ b/reg-lib/cuda/_reg_lncc_gpu.h
@@ -1,7 +1,7 @@
 /*
- * @file _reg_ssd_gpu.h
+ * @file _reg_lncc_gpu.h
  * @author Marc Modat
- * @date 14/11/2012
+ * @date 10/11/2012
  *
  *  Copyright (c) 2009-2018, University College London
  *  Copyright (c) 2018, NiftyReg Developers.
@@ -13,19 +13,20 @@
 #pragma once
 
 #include "CudaTools.hpp"
+#include "CudaKernelConvolution.hpp"
 #include "_reg_measure_gpu.h"
-#include "_reg_ssd.h"
+#include "_reg_lncc.h"
 
 /* *************************************************************** */
-/// @brief SSD measure of similarity class on the device
-class reg_ssd_gpu: public reg_ssd, public reg_measure_gpu {
+/// @brief LNCC measure of similarity class on the device
+class reg_lncc_gpu: public reg_lncc, public reg_measure_gpu {
 public:
-    /// @brief reg_ssd class constructor
-    reg_ssd_gpu();
-    /// @brief Measure class destructor
-    virtual ~reg_ssd_gpu();
+    /// @brief reg_lncc_gpu class constructor
+    reg_lncc_gpu();
+    /// @brief reg_lncc_gpu class destructor
+    virtual ~reg_lncc_gpu();
 
-    /// @brief Initialise the reg_ssd object
+    /// @brief Initialise the reg_lncc_gpu object
     // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
     using reg_measure::InitialiseMeasure;
     virtual void InitialiseMeasure(nifti_image *refImg,
@@ -52,13 +53,38 @@ public:
                                    nifti_image *voxelBasedGradBw = nullptr,
                                    float4 *voxelBasedGradBwCuda = nullptr,
                                    size_t activeVoxNumBw = 0) override;
-    /// @brief Returns the ssd value forwards
+    /// @brief Returns the lncc value forwards
     virtual double GetSimilarityMeasureValueFw() override;
-    /// @brief Returns the ssd value backwards
+    /// @brief Returns the lncc value backwards
     virtual double GetSimilarityMeasureValueBw() override;
-    /// @brief Compute the voxel-based ssd gradient forwards
+    /// @brief Compute the voxel-based lncc gradient forwards
     virtual void GetVoxelBasedSimilarityMeasureGradientFw(int currentTimePoint) override;
-    /// @brief Compute the voxel-based ssd gradient backwards
+    /// @brief Compute the voxel-based lncc gradient backwards
     virtual void GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint) override;
+
+protected:
+    // Device scratch buffers mirroring the CPU reg_lncc images. The four local statistics are
+    // packed into the lanes of ONE float4 image (x = mean, y = sdev, z = warpedMean,
+    // w = warpedSdev) so the shared Cuda::KernelConvolutionPacked smooths all four in a single
+    // pass with fully coalesced accesses; per lane the maths is identical to convolving each
+    // image alone, preserving bit-exactness with the CPU. The correlation image uses lane .x
+    // (the gradient reuses its lanes x/y/z for the three temp fields it smooths).
+    thrust::device_vector<float4> statsImageCuda;
+    thrust::device_vector<float4> correlationImageCuda;
+    // Per-voxel masks: the base mask is the host reg_measure mask uploaded ONCE at initialise
+    // time; the combined mask (base minus every voxel NaN in the reference or warped image) is
+    // rebuilt on device each call without any host transfer.
+    thrust::device_vector<int> baseMaskCuda;
+    thrust::device_vector<int> forwardMaskCuda;
+
+    thrust::device_vector<float4> statsImageBwCuda;
+    thrust::device_vector<float4> correlationImageBwCuda;
+    thrust::device_vector<int> baseMaskBwCuda;
+    thrust::device_vector<int> backwardMaskCuda;
+
+    // Reusable convolution scratch: avoids per-call cudaMalloc/cudaFree and lets the
+    // convolutions of one similarity value share a single smoothed-density computation, since they
+    // all use the same combined mask (which already excludes every NaN voxel).
+    NiftyReg::Cuda::KernelConvolutionWorkspace convWorkspace;
 };
 /* *************************************************************** */

--- a/reg-lib/cuda/_reg_lncc_gpu.h
+++ b/reg-lib/cuda/_reg_lncc_gpu.h
@@ -1,15 +1,3 @@
-/*
- * @file _reg_lncc_gpu.h
- * @author Marc Modat
- * @date 10/11/2012
- *
- *  Copyright (c) 2009-2018, University College London
- *  Copyright (c) 2018, NiftyReg Developers.
- *  All rights reserved.
- * See the LICENSE.txt file in the nifty_reg root folder
- *
- */
-
 #pragma once
 
 #include "CudaTools.hpp"

--- a/reg-lib/cuda/_reg_measure_gpu.h
+++ b/reg-lib/cuda/_reg_measure_gpu.h
@@ -43,7 +43,8 @@ public:
                                    nifti_image *warpedGradBw = nullptr,
                                    float4 *warpedGradBwCuda = nullptr,
                                    nifti_image *voxelBasedGradBw = nullptr,
-                                   float4 *voxelBasedGradBwCuda = nullptr) {
+                                   float4 *voxelBasedGradBwCuda = nullptr,
+                                   size_t activeVoxNumBw = 0) {
         // Check that the input image are of type float
         if (refImg->datatype != NIFTI_TYPE_FLOAT32 || warpedImg->datatype != NIFTI_TYPE_FLOAT32)
             NR_FATAL_ERROR("Only single precision is supported on the GPU");
@@ -62,6 +63,7 @@ public:
             if (floImg->datatype != NIFTI_TYPE_FLOAT32 || warpedImgBw->datatype != NIFTI_TYPE_FLOAT32)
                 NR_FATAL_ERROR("Only single precision is supported on the GPU");
             this->floatingMaskCuda = floMaskCuda;
+            this->activeVoxelNumberBw = activeVoxNumBw;
             this->warpedImageBwCuda = warpedImgBwCuda;
             this->warpedGradientBwCuda = warpedGradBwCuda;
             this->voxelBasedGradientBwCuda = voxelBasedGradBwCuda;
@@ -79,6 +81,7 @@ protected:
     float *floatingImageCuda = nullptr;
     int *referenceMaskCuda = nullptr;
     size_t activeVoxelNumber = 0;
+    size_t activeVoxelNumberBw = 0;
     float *warpedImageCuda = nullptr;
     float4 *warpedGradientCuda = nullptr;
     float4 *voxelBasedGradientCuda = nullptr;
@@ -90,49 +93,6 @@ protected:
     float4 *voxelBasedGradientBwCuda = nullptr;
 };
 /* *************************************************************** */
-class reg_lncc_gpu: public reg_lncc, public reg_measure_gpu {
-public:
-    /// @brief reg_lncc class constructor
-    reg_lncc_gpu() {
-        NR_FATAL_ERROR("CUDA CANNOT BE USED WITH LNCC YET");
-    }
-    /// @brief reg_lncc class destructor
-    virtual ~reg_lncc_gpu() {}
-
-    // Bring the CPU base overload into scope; the GPU override below intentionally adds a second overload
-    using reg_measure::InitialiseMeasure;
-    virtual void InitialiseMeasure(nifti_image *refImg,
-                                   float *refImgCuda,
-                                   nifti_image *floImg,
-                                   float *floImgCuda,
-                                   int *refMask,
-                                   int *refMaskCuda,
-                                   size_t activeVoxNum,
-                                   nifti_image *warpedImg,
-                                   float *warpedImgCuda,
-                                   nifti_image *warpedGrad,
-                                   float4 *warpedGradCuda,
-                                   nifti_image *voxelBasedGrad,
-                                   float4 *voxelBasedGradCuda,
-                                   nifti_image *localWeightSim = nullptr,
-                                   float *localWeightSimCuda = nullptr,
-                                   int *floMask = nullptr,
-                                   int *floMaskCuda = nullptr,
-                                   nifti_image *warpedImgBw = nullptr,
-                                   float *warpedImgBwCuda = nullptr,
-                                   nifti_image *warpedGradBw = nullptr,
-                                   float4 *warpedGradBwCuda = nullptr,
-                                   nifti_image *voxelBasedGradBw = nullptr,
-                                   float4 *voxelBasedGradBwCuda = nullptr) override {}
-    /// @brief Returns the lncc value forwards
-    virtual double GetSimilarityMeasureValueFw() override { return 0; }
-    /// @brief Returns the lncc value backwards
-    virtual double GetSimilarityMeasureValueBw() override { return 0; }
-    /// @brief Compute the voxel-based lncc gradient forwards
-    virtual void GetVoxelBasedSimilarityMeasureGradientFw(int currentTimePoint) override {}
-    /// @brief Compute the voxel-based lncc gradient backwards
-    virtual void GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint) override {}
-};
 /* *************************************************************** */
 class reg_kld_gpu: public reg_kld, public reg_measure_gpu {
 public:
@@ -167,7 +127,8 @@ public:
                                    nifti_image *warpedGradBw = nullptr,
                                    float4 *warpedGradBwCuda = nullptr,
                                    nifti_image *voxelBasedGradBw = nullptr,
-                                   float4 *voxelBasedGradBwCuda = nullptr) override {}
+                                   float4 *voxelBasedGradBwCuda = nullptr,
+                                   size_t activeVoxNumBw = 0) override {}
     /// @brief Returns the kld value forwards
     virtual double GetSimilarityMeasureValueFw() override { return 0; }
     /// @brief Returns the kld value backwards
@@ -211,7 +172,8 @@ public:
                                    nifti_image *warpedGradBw = nullptr,
                                    float4 *warpedGradBwCuda = nullptr,
                                    nifti_image *voxelBasedGradBw = nullptr,
-                                   float4 *voxelBasedGradBwCuda = nullptr) override {}
+                                   float4 *voxelBasedGradBwCuda = nullptr,
+                                   size_t activeVoxNumBw = 0) override {}
     /// @brief Returns the dti value forwards
     virtual double GetSimilarityMeasureValueFw() override { return 0; }
     /// @brief Returns the dti value backwards

--- a/reg-lib/cuda/_reg_nmi_gpu.cu
+++ b/reg-lib/cuda/_reg_nmi_gpu.cu
@@ -32,13 +32,14 @@ void reg_nmi_gpu::InitialiseMeasure(nifti_image *refImg, float *refImgCuda,
                                     int *floMask, int *floMaskCuda,
                                     nifti_image *warpedImgBw, float *warpedImgBwCuda,
                                     nifti_image *warpedGradBw, float4 *warpedGradBwCuda,
-                                    nifti_image *voxelBasedGradBw, float4 *voxelBasedGradBwCuda) {
+                                    nifti_image *voxelBasedGradBw, float4 *voxelBasedGradBwCuda,
+                                    size_t activeVoxNumBw) {
     reg_nmi::InitialiseMeasure(refImg, floImg, refMask, warpedImg, warpedGrad, voxelBasedGrad,
                                localWeightSim, floMask, warpedImgBw, warpedGradBw, voxelBasedGradBw);
     reg_measure_gpu::InitialiseMeasure(refImg, refImgCuda, floImg, floImgCuda, refMask, refMaskCuda, activeVoxNum,
                                        warpedImg, warpedImgCuda, warpedGrad, warpedGradCuda, voxelBasedGrad, voxelBasedGradCuda,
                                        localWeightSim, localWeightSimCuda, floMask, floMaskCuda, warpedImgBw, warpedImgBwCuda,
-                                       warpedGradBw, warpedGradBwCuda, voxelBasedGradBw, voxelBasedGradBwCuda);
+                                       warpedGradBw, warpedGradBwCuda, voxelBasedGradBw, voxelBasedGradBwCuda, activeVoxNumBw);
     // The reference and floating images have to be updated on the device
     Cuda::TransferNiftiToDevice(this->referenceImageCuda, this->referenceImage);
     Cuda::TransferNiftiToDevice(this->floatingImageCuda, this->floatingImage);
@@ -282,7 +283,7 @@ double reg_nmi_gpu::GetSimilarityMeasureValueBw() {
                                        this->jointHistogramProBwCudaVecs,
                                        this->entropyValuesBw,
                                        this->floatingMaskCuda,
-                                       this->activeVoxelNumber,
+                                       this->activeVoxelNumberBw,
                                        this->approximatePw);
 }
 /* *************************************************************** */
@@ -404,7 +405,7 @@ void reg_nmi_gpu::GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint)
                              this->jointHistogramLogBwCudaVecs[currentTimePoint].data().get(),
                              this->voxelBasedGradientBwCuda,
                              this->floatingMaskCuda,
-                             this->activeVoxelNumber,
+                             this->activeVoxelNumberBw,
                              this->entropyValuesBw[currentTimePoint],
                              this->floatingBinNumber[currentTimePoint],
                              this->referenceBinNumber[currentTimePoint],

--- a/reg-lib/cuda/_reg_nmi_gpu.h
+++ b/reg-lib/cuda/_reg_nmi_gpu.h
@@ -49,7 +49,8 @@ public:
                                    nifti_image *warpedGradBw = nullptr,
                                    float4 *warpedGradBwCuda = nullptr,
                                    nifti_image *voxelBasedGradBw = nullptr,
-                                   float4 *voxelBasedGradBwCuda = nullptr) override;
+                                   float4 *voxelBasedGradBwCuda = nullptr,
+                                   size_t activeVoxNumBw = 0) override;
     /// @brief Returns the nmi value forwards
     virtual double GetSimilarityMeasureValueFw() override;
     /// @brief Returns the nmi value backwards

--- a/reg-lib/cuda/_reg_ssd_gpu.cu
+++ b/reg-lib/cuda/_reg_ssd_gpu.cu
@@ -32,13 +32,14 @@ void reg_ssd_gpu::InitialiseMeasure(nifti_image *refImg, float *refImgCuda,
                                     int *floMask, int *floMaskCuda,
                                     nifti_image *warpedImgBw, float *warpedImgBwCuda,
                                     nifti_image *warpedGradBw, float4 *warpedGradBwCuda,
-                                    nifti_image *voxelBasedGradBw, float4 *voxelBasedGradBwCuda) {
+                                    nifti_image *voxelBasedGradBw, float4 *voxelBasedGradBwCuda,
+                                    size_t activeVoxNumBw) {
     reg_ssd::InitialiseMeasure(refImg, floImg, refMask, warpedImg, warpedGrad, voxelBasedGrad,
                                localWeightSim, floMask, warpedImgBw, warpedGradBw, voxelBasedGradBw);
     reg_measure_gpu::InitialiseMeasure(refImg, refImgCuda, floImg, floImgCuda, refMask, refMaskCuda, activeVoxNum,
                                        warpedImg, warpedImgCuda, warpedGrad, warpedGradCuda, voxelBasedGrad, voxelBasedGradCuda,
                                        localWeightSim, localWeightSimCuda, floMask, floMaskCuda, warpedImgBw, warpedImgBwCuda,
-                                       warpedGradBw, warpedGradBwCuda, voxelBasedGradBw, voxelBasedGradBwCuda);
+                                       warpedGradBw, warpedGradBwCuda, voxelBasedGradBw, voxelBasedGradBwCuda, activeVoxNumBw);
     // Check if the reference and floating images need to be updated
     for (int i = 0; i < this->referenceTimePoints; ++i)
         if (this->timePointWeights[i] > 0 && normaliseTimePoint[i]) {
@@ -108,7 +109,7 @@ double reg_ssd_gpu::GetSimilarityMeasureValueBw() {
                                this->warpedImageBwCuda,
                                nullptr,
                                this->floatingMaskCuda,
-                               this->activeVoxelNumber,
+                               this->activeVoxelNumberBw,
                                this->timePointWeights,
                                this->referenceTimePoints);
 }
@@ -197,7 +198,7 @@ void reg_ssd_gpu::GetVoxelBasedSimilarityMeasureGradientBw(int currentTimePoint)
                                      nullptr,
                                      this->voxelBasedGradientBwCuda,
                                      this->floatingMaskCuda,
-                                     this->activeVoxelNumber,
+                                     this->activeVoxelNumberBw,
                                      this->timePointWeights[currentTimePoint],
                                      currentTimePoint);
 }

--- a/reg-test/reg_test_regr_kernelConvolution.cpp
+++ b/reg-test/reg_test_regr_kernelConvolution.cpp
@@ -134,13 +134,205 @@ public:
 
             // Compute the kernel convolution for CPU and CUDA
             reg_tools_kernelConvolution(contentCpu->GetDeformationField(), sigmaValues.data(), ConvKernelType(kernelType), nullptr, activeTimePoints, activeAxes);
-            cudaKernelConvolution(contentCuda->Content::GetDeformationField(), contentCuda->GetDeformationFieldCuda(), sigmaValues.data(), activeTimePoints, activeAxes);
+            cudaKernelConvolution(contentCuda->Content::GetDeformationField(), contentCuda->GetDeformationFieldCuda(), sigmaValues.data(), activeTimePoints, activeAxes, nullptr, nullptr);
 
             // Save the results for testing
             testCases.push_back({ testName, std::move(contentCpu->GetDeformationField()), std::move(contentCuda->GetDeformationField()) });
         }
     }
 };
+
+/**
+ * Multi-image convolution regression for every kernel type, with a mask and a shared NaN
+ * pattern, for both accumulation types (CPU) and including a size whose z-axis sliding window
+ * overflows L2 so the packed path takes the column-parallel variant while the single-channel
+ * reference stays voxel-parallel (CUDA).
+**/
+class KernelConvolutionMultiTest {
+protected:
+    using TestCase = std::tuple<std::string, vector<NiftiImage>, vector<NiftiImage>>;
+
+    inline static vector<TestCase> testCases;
+
+public:
+    KernelConvolutionMultiTest() {
+        if (!testCases.empty())
+            return;
+
+        std::mt19937 gen(1);
+        std::uniform_real_distribution<float> distr(0, 1);
+
+        // Geometries: 2D, 3D, and a 3D size large enough that the CUDA packed z pass takes the
+        // column-parallel variant (sliding window > L2/2) while the single-channel path does not
+        const vector<vector<NiftiImage::dim_t>> dimsList{ { 16, 16 }, { 16, 16, 16 }, { 192, 192, 8 } };
+        constexpr int kernelTypeCount = 4;
+        const float sigma = -5.f;  // voxel-based, same for every image (the multi-image contract)
+
+        // Fill an image with random values; NaN out the same voxel set in every image (the
+        // multi-image functions require an identical NaN pattern across images)
+        auto makeImages = [&](const vector<NiftiImage::dim_t>& dims, const int imageCount) {
+            vector<NiftiImage> images(imageCount);
+            for (int c = 0; c < imageCount; c++) {
+                images[c] = NiftiImage(dims, NIFTI_TYPE_FLOAT32);
+                auto imagePtr = images[c].data();
+                for (size_t i = 0; i < images[c].nVoxels(); i++)
+                    imagePtr[i] = distr(gen);
+            }
+            for (size_t i = 0; i < images[0].nVoxels(); i += 37)
+                for (int c = 0; c < imageCount; c++)
+                    images[c].data()[i] = std::numeric_limits<float>::quiet_NaN();
+            return images;
+        };
+        auto makeMask = [](const size_t voxelNumber) {
+            vector<int> mask(voxelNumber);
+            for (size_t i = 0; i < voxelNumber; i++)
+                mask[i] = i % 7 == 0 ? -1 : 0;
+            return mask;
+        };
+
+        for (const auto& dims : dimsList) {
+            for (int kernelType = 0; kernelType < kernelTypeCount; kernelType++) {
+                /* ------------------------------- CPU: multi vs single ------------------------------ */
+                for (const int imageCount : { 2, 3, 4 }) {
+                    for (const bool useFloatAcc : { false, true }) {
+                        const vector<NiftiImage> images = makeImages(dims, imageCount);
+                        const vector<int> mask = makeMask(images[0].nVoxels());
+
+                        // Reference: each image convolved ALONE (density recomputed every time)
+                        vector<NiftiImage> expected(images.begin(), images.end());
+                        ConvolutionWorkspace wsSingle;
+                        wsSingle.useFloatAccumulation = useFloatAcc;
+                        for (int c = 0; c < imageCount; c++) {
+                            wsSingle.densityValid = false;
+                            reg_tools_kernelConvolution(expected[c], &sigma, ConvKernelType(kernelType),
+                                                        mask.data(), nullptr, nullptr, &wsSingle);
+                        }
+
+                        // Actual: one multi-image sweep
+                        vector<NiftiImage> actual(images.begin(), images.end());
+                        vector<nifti_image*> actualPtrs(imageCount);
+                        for (int c = 0; c < imageCount; c++) actualPtrs[c] = actual[c];
+                        ConvolutionWorkspace wsMulti;
+                        wsMulti.useFloatAccumulation = useFloatAcc;
+                        reg_tools_kernelConvolutionMulti(actualPtrs.data(), imageCount, &sigma,
+                                                         ConvKernelType(kernelType), mask.data(), &wsMulti);
+
+                        const std::string dimsStr = std::accumulate(dims.begin(), dims.end(), ""s,
+                            [](const std::string& str, const auto& val) { return str + " "s + std::to_string(val); });
+                        testCases.push_back({ "CPU Multi Kernel: "s + std::to_string(kernelType) +
+                                              " Images: "s + std::to_string(imageCount) +
+                                              (useFloatAcc ? " FloatAcc" : " DoubleAcc") +
+                                              " Dims:"s + dimsStr,
+                                              std::move(expected), std::move(actual) });
+                    }
+                }
+
+                /* ------------- CPU: workspace-less / mask-less / single-image entry points --------- */
+                if (&dims == &dimsList[0]) {
+                    const vector<NiftiImage> images = makeImages(dims, 2);
+
+                    // N=2 with neither workspace nor mask (locally allocated scratch, all-active mask)
+                    vector<NiftiImage> expected(images.begin(), images.end());
+                    for (int c = 0; c < 2; c++)
+                        reg_tools_kernelConvolution(expected[c], &sigma, ConvKernelType(kernelType));
+                    vector<NiftiImage> actual(images.begin(), images.end());
+                    vector<nifti_image*> actualPtrs{ actual[0], actual[1] };
+                    reg_tools_kernelConvolutionMulti(actualPtrs.data(), 2, &sigma, ConvKernelType(kernelType));
+
+                    // N=1 delegates to the single-image convolution
+                    NiftiImage oneExpected(images[0]), oneActual(images[0]);
+                    reg_tools_kernelConvolution(oneExpected, &sigma, ConvKernelType(kernelType));
+                    nifti_image *onePtr = oneActual;
+                    reg_tools_kernelConvolutionMulti(&onePtr, 1, &sigma, ConvKernelType(kernelType));
+                    expected.push_back(std::move(oneExpected));
+                    actual.push_back(std::move(oneActual));
+
+                    testCases.push_back({ "CPU Multi Kernel: "s + std::to_string(kernelType) +
+                                          " NoWorkspaceNoMask", std::move(expected), std::move(actual) });
+                }
+
+                /* ---------------------------- CUDA: packed vs single-channel ----------------------- */
+                {
+                    // Four images packed as the four time points of one image: CudaContent stores an
+                    // nt=4 deformation field as one float4 per voxel, i.e. one image per lane. The
+                    // NaN pattern must be identical across the lanes (multi-image contract), so the
+                    // NaNs are injected per 3D voxel into all four planes.
+                    vector<NiftiImage::dim_t> dims4(dims);
+                    dims4.resize(4, 1);
+                    dims4[3] = 4;
+                    NiftiImage packedImage(dims4, NIFTI_TYPE_FLOAT32);
+                    const size_t voxelNumber = packedImage.nVoxels() / 4;  // 4 time points (lanes)
+                    auto packedPtr = packedImage.data();
+                    for (size_t i = 0; i < packedImage.nVoxels(); i++)
+                        packedPtr[i] = distr(gen);
+                    for (size_t i = 0; i < voxelNumber; i += 37)
+                        for (int t = 0; t < 4; t++)
+                            packedPtr[t * voxelNumber + i] = std::numeric_limits<float>::quiet_NaN();
+                    const vector<int> mask = makeMask(voxelNumber);
+                    int *maskCudaPtr = nullptr;
+                    Cuda::Allocate<int>(&maskCudaPtr, voxelNumber);
+                    Cuda::UniquePtr<int> maskCuda(maskCudaPtr);
+                    Cuda::TransferFromHostToDevice<int>(maskCudaPtr, mask.data(), voxelNumber);
+
+                    // Reference: the single-channel convolution applied to each lane in turn (the
+                    // same sigma for every lane)
+                    NiftiImage imageSingle(packedImage), imagePacked(packedImage);
+                    unique_ptr<CudaContent> contentSingle{ new CudaContent(imageSingle, imageSingle, nullptr, nullptr, sizeof(float)) };
+                    unique_ptr<CudaContent> contentPacked{ new CudaContent(imagePacked, imagePacked, nullptr, nullptr, sizeof(float)) };
+                    contentSingle->SetDeformationField(std::move(imageSingle));
+                    contentPacked->SetDeformationField(std::move(imagePacked));
+
+                    const float sigma4[4]{ sigma, sigma, sigma, sigma };
+                    Cuda::KernelConvolutionWorkspace wsCudaSingle, wsCudaPacked;
+                    auto cudaSingle = Cuda::KernelConvolution<ConvKernelType(0), float>;
+                    auto cudaPacked = Cuda::KernelConvolutionPacked<ConvKernelType(0), float>;
+                    switch (kernelType) {
+                    case 1: cudaSingle = Cuda::KernelConvolution<ConvKernelType(1), float>; cudaPacked = Cuda::KernelConvolutionPacked<ConvKernelType(1), float>; break;
+                    case 2: cudaSingle = Cuda::KernelConvolution<ConvKernelType(2), float>; cudaPacked = Cuda::KernelConvolutionPacked<ConvKernelType(2), float>; break;
+                    case 3: cudaSingle = Cuda::KernelConvolution<ConvKernelType(3), float>; cudaPacked = Cuda::KernelConvolutionPacked<ConvKernelType(3), float>; break;
+                    }
+                    cudaSingle(contentSingle->Content::GetDeformationField(), contentSingle->GetDeformationFieldCuda(),
+                               sigma4, nullptr, nullptr, maskCudaPtr, &wsCudaSingle);
+                    cudaPacked(contentPacked->Content::GetDeformationField(), contentPacked->GetDeformationFieldCuda(),
+                               sigma4, maskCudaPtr, &wsCudaPacked);
+
+                    const std::string dimsStr = std::accumulate(dims.begin(), dims.end(), ""s,
+                        [](const std::string& str, const auto& val) { return str + " "s + std::to_string(val); });
+                    vector<NiftiImage> expected, actual;
+                    expected.push_back(std::move(contentSingle->GetDeformationField()));
+                    actual.push_back(std::move(contentPacked->GetDeformationField()));
+                    testCases.push_back({ "CUDA Packed Kernel: "s + std::to_string(kernelType) + " Dims:"s + dimsStr,
+                                          std::move(expected), std::move(actual) });
+                }
+            }
+        }
+    }
+};
+
+TEST_CASE_METHOD(KernelConvolutionMultiTest, "Regression Kernel Convolution Multi", "[regression]") {
+    for (auto&& testCase : testCases) {
+        auto&& [testName, expected, actual] = testCase;
+
+        SECTION(testName) {
+            NR_COUT << "\n**************** Section " << testName << " ****************" << std::endl;
+            NR_COUT << std::fixed << std::setprecision(10);
+
+            for (size_t c = 0; c < expected.size(); ++c) {
+                const auto expectedPtr = expected[c].data();
+                const auto actualPtr = actual[c].data();
+                for (size_t i = 0; i < expected[c].nVoxels(); ++i) {
+                    const float expectedVal = expectedPtr[i];
+                    const float actualVal = actualPtr[i];
+                    if (expectedVal != expectedVal && actualVal != actualVal) continue;  // Skip NaN values
+                    const float diff = fabs(expectedVal - actualVal);
+                    if (diff > 0)
+                        NR_COUT << "img " << c << " vox " << i << " " << expectedVal << " " << actualVal << std::endl;
+                    REQUIRE(diff == 0);
+                }
+            }
+        }
+    }
+}
 
 TEST_CASE_METHOD(KernelConvolutionTest, "Regression Kernel Convolution", "[regression]") {
     // Loop over all generated test cases

--- a/reg-test/reg_test_regr_measure.cpp
+++ b/reg-test/reg_test_regr_measure.cpp
@@ -13,7 +13,7 @@
 class MeasureTest {
 protected:
     using TestData = std::tuple<std::string, NiftiImage, NiftiImage, NiftiImage, NiftiImage, MeasureType, bool>;
-    using TestCase = std::tuple<std::string, double, double, NiftiImage, NiftiImage>;
+    using TestCase = std::tuple<std::string, double, double, NiftiImage, NiftiImage, NiftiImage, NiftiImage>;
 
     inline static vector<TestCase> testCases;
 
@@ -62,9 +62,24 @@ public:
             localWeightSim3dPtr[i] = distr(gen);
         }
 
+        // Create floating images with a DIFFERENT size than the reference. The backward similarity
+        // of a symmetric registration runs in floating space, so a floating voxel count that differs
+        // from the reference's exercises the backward measure with a distinct active voxel number -
+        vector<NiftiImage::dim_t> dimBig{ size, size / 2, 1, timePoints };  // 2D: 128 voxels/time point
+        NiftiImage floatingBig2d(dimBig, NIFTI_TYPE_FLOAT32);
+        dimBig[1] = size;
+        dimBig[2] = size / 2;  // 3D: 16 x 16 x 8 = 2048 voxels/time point
+        NiftiImage floatingBig3d(dimBig, NIFTI_TYPE_FLOAT32);
+        auto floBig2dPtr = floatingBig2d.data();
+        for (size_t i = 0; i < floatingBig2d.nVoxels(); ++i)
+            floBig2dPtr[i] = distr(gen);
+        auto floBig3dPtr = floatingBig3d.data();
+        for (size_t i = 0; i < floatingBig3d.nVoxels(); ++i)
+            floBig3dPtr[i] = distr(gen);
+
         // Create the data container for the regression test
         const std::string measureNames[]{ "NMI"s, "SSD"s, "DTI"s, "LNCC"s, "KLD"s, "MIND"s, "MINDSSC"s };
-        constexpr MeasureType testMeasures[]{ MeasureType::Nmi, MeasureType::Ssd };
+        constexpr MeasureType testMeasures[]{ MeasureType::Nmi, MeasureType::Ssd, MeasureType::Lncc };
         vector<TestData> testData;
         for (auto&& measure : testMeasures) {
             for (int sym = 0; sym < 2; ++sym) {
@@ -89,6 +104,18 @@ public:
             }
         }
 
+        // Symmetric cases with reference and floating of different sizes (see floatingBig above).
+        // Only the measures that reused the forward voxel count on the backward path are affected.
+        constexpr MeasureType asymMeasures[]{ MeasureType::Nmi, MeasureType::Ssd };
+        for (auto&& measure : asymMeasures) {
+            testData.emplace_back(TestData(
+                measureNames[int(measure)] + " 2D Symmetric DifferentSize"s,
+                reference2d, floatingBig2d, controlPointGrid2d, localWeightSim2d, measure, true));
+            testData.emplace_back(TestData(
+                measureNames[int(measure)] + " 3D Symmetric DifferentSize"s,
+                reference3d, floatingBig3d, controlPointGrid3d, localWeightSim3d, measure, true));
+        }
+
         // Create the platforms
         Platform platformCpu(PlatformType::Cpu);
         Platform platformCuda(PlatformType::Cuda);
@@ -109,7 +136,10 @@ public:
             NiftiImage referenceCpu(reference), referenceCuda(reference);
             NiftiImage floatingCpu(floating), floatingCuda(floating);
             NiftiImage controlPointGridCpu(controlPointGrid), controlPointGridCuda(controlPointGrid);
-            NiftiImage controlPointGridCpuBw(controlPointGrid), controlPointGridCudaBw(controlPointGrid);
+            // The backward control point grid is parametrised in floating space, so build it from
+            // the floating image (identical to the forward grid when the two images share a size).
+            NiftiImage controlPointGridBw(CreateControlPointGrid(floating));
+            NiftiImage controlPointGridCpuBw(controlPointGridBw), controlPointGridCudaBw(controlPointGridBw);
             NiftiImage localWeightSimCpu(localWeightSim), localWeightSimCuda(localWeightSim);
 
             // Create the contents
@@ -184,9 +214,17 @@ public:
                 measureCuda->GetVoxelBasedSimilarityMeasureGradient(t);
             }
 
-            // Save the results for testing
+            // Save the results for testing. For symmetric registrations also keep the backward
+            // voxel-based gradient (computed in floating space) so its CPU/CUDA agreement is
+            // checked too; left empty otherwise.
+            NiftiImage voxelBasedGradCpuBw, voxelBasedGradCudaBw;
+            if (isSymmetric) {
+                voxelBasedGradCpuBw = std::move(contentCpuBw->GetVoxelBasedMeasureGradient());
+                voxelBasedGradCudaBw = std::move(contentCudaBw->GetVoxelBasedMeasureGradient());
+            }
             testCases.push_back({ testName, simMeasureCpu, simMeasureCuda, std::move(contentCpu->GetVoxelBasedMeasureGradient()),
-                                std::move(contentCuda->GetVoxelBasedMeasureGradient()) });
+                                std::move(contentCuda->GetVoxelBasedMeasureGradient()),
+                                std::move(voxelBasedGradCpuBw), std::move(voxelBasedGradCudaBw) });
         }
     }
 };
@@ -195,7 +233,8 @@ TEST_CASE_METHOD(MeasureTest, "Regression Measure", "[regression]") {
     // Loop over all generated test cases
     for (auto&& testCase : testCases) {
         // Retrieve test information
-        auto&& [testName, simMeasureCpu, simMeasureCuda, voxelBasedGradCpu, voxelBasedGradCuda] = testCase;
+        auto&& [testName, simMeasureCpu, simMeasureCuda, voxelBasedGradCpu, voxelBasedGradCuda,
+                voxelBasedGradCpuBw, voxelBasedGradCudaBw] = testCase;
 
         SECTION(testName) {
             NR_COUT << "\n**************** Section " << testName << " ****************" << std::endl;
@@ -225,6 +264,19 @@ TEST_CASE_METHOD(MeasureTest, "Regression Measure", "[regression]") {
             NR_COUT << "Value  |cpu-cuda|=" << fabs(simMeasureCpu - simMeasureCuda) << std::endl;
             NR_COUT << "Grad   max|cpu-cuda|=" << maxGradDiff << "  (max|cpu|=" << maxGradMag
                     << ", relative=" << (maxGradMag > 0 ? maxGradDiff / maxGradMag : 0) << ")" << std::endl;
+
+            // Check the backward voxel-based gradient too (symmetric cases only)
+            if (voxelBasedGradCpuBw) {
+                const auto voxelBasedGradCpuBwPtr = voxelBasedGradCpuBw.data();
+                const auto voxelBasedGradCudaBwPtr = voxelBasedGradCudaBw.data();
+                for (size_t i = 0; i < voxelBasedGradCpuBw.nVoxels(); ++i) {
+                    const float cpuVal = voxelBasedGradCpuBwPtr[i];
+                    const float cudaVal = voxelBasedGradCudaBwPtr[i];
+                    if (fabs(cpuVal - cudaVal) > 0)
+                        NR_COUT << "Bw " << i << " " << cpuVal << " " << cudaVal << std::endl;
+                    REQUIRE(fabs(cpuVal - cudaVal) == 0);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Ported LNCC using CUDA - it produces identical results to the cpu version

Optimised the convolution kernel. Change both CPU and GPU to use float to accumulate when computing LNCC. Use scratch variable when doing multiple passes to avoid unecessary alloc/free. Enable multiple image convolution with shared mask at once using float4 (ported similar concept to CPU). Added a pingpong over two arrays to avoid copying after each pass (while at it, did the same for scaling and squaring to exponentiate velocity field).

Identified a bug in nmi and ssd when forward and backward reference spaces have different active voxel numbers (forward number was used for both).

Left to do: I need to benchmark the cpu version on an x64 core to check what to do with the SSE version within the convolution kernel on CPU. Suspicion is that I might remove it and use instead the optimised multi-pass version. Will also, check the impact of FP32 vs FP64 on computation time on H200 rather than GB10.